### PR TITLE
Provide optimization information to operators during execution

### DIFF
--- a/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuantaBuilder.scala
+++ b/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuantaBuilder.scala
@@ -1309,6 +1309,29 @@ class DoWhileDataQuantaBuilder[T, ConvOut](inputDataQuanta: DataQuantaBuilder[_,
     this
   }
 
+  /**
+    * Explicitly set the [[DataSetType]] for the condition [[DataQuanta]]. Note that it is not
+    * always necessary to set it and that it can be inferred in some situations.
+    *
+    * @param outputType the output [[DataSetType]]
+    * @return this instance
+    */
+  def withConditionType(outputType: DataSetType[ConvOut]) = {
+    this.convOutClassTag = ClassTag(outputType.getDataUnitType.getTypeClass)
+    this
+  }
+
+  /**
+    * Explicitly set the [[Class]] for the condition [[DataQuanta]]. Note that it is not
+    * always necessary to set it and that it can be inferred in some situations.
+    *
+    * @param cls the output [[Class]]
+    * @return this instance
+    */
+  def withConditionClass(cls: Class[ConvOut]) = {
+    this.convOutClassTag = ClassTag(cls)
+    this
+  }
 
   /**
     * Set the number of expected iterations for the built [[org.qcri.rheem.basic.operators.DoWhileOperator]].

--- a/rheem-core/src/main/java/org/qcri/rheem/core/function/ExecutionContext.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/function/ExecutionContext.java
@@ -1,5 +1,6 @@
 package org.qcri.rheem.core.function;
 
+import org.qcri.rheem.core.plan.rheemplan.LoopSubplan;
 import org.qcri.rheem.core.platform.Platform;
 
 import java.util.Collection;
@@ -18,5 +19,13 @@ public interface ExecutionContext {
      * @return the broadcast
      */
     <T> Collection<T> getBroadcast(String name);
+
+    /**
+     * If this instance reflects the state of execution inside of a {@link LoopSubplan}, then retrieve the
+     * number of the current iteration.
+     *
+     * @return the iteration number, start at {@code 0}, or {@code -1} if there is no surrounding {@link LoopSubplan}
+     */
+    int getCurrentIteration();
 
 }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/CrossPlatformExecutor.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/CrossPlatformExecutor.java
@@ -363,7 +363,7 @@ public class CrossPlatformExecutor implements ExecutionState {
         final ExecutionStage processedStage = processedStageActivator.getStage();
         if (processedStage.getLoop() == successorStage.getLoop()) {
             if (successorStage.isLoopHead()) {
-                prevOptimizationContext.getNextIterationContext(); // TODO: Make up new contexts if needed.
+                return prevOptimizationContext.getNextIterationContext(); // TODO: Make up new contexts if needed.
             } else {
                 return prevOptimizationContext;
             }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
@@ -52,7 +52,7 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
      */
     private Tuple<List<ChannelInstance>, PartialExecution> execute(TaskActivator taskActivator, boolean isForceExecution) {
         // Execute the ExecutionTask.
-        this.open(taskActivator.getTask(), taskActivator.getInputChannelInstances());
+        this.open(taskActivator.getTask(), taskActivator.getInputChannelInstances(), taskActivator.getOperatorContext());
 
         return this.execute(
                 taskActivator.getTask(),
@@ -92,9 +92,12 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
      *
      * @param task                  that should be executed
      * @param inputChannelInstances inputs into the {@code task}
+     * @param operatorContext       contains optimization information on the wrapped {@link ExecutionOperator}
      * @return the {@link ChannelInstance}s created as output of {@code task}
      */
-    protected abstract void open(ExecutionTask task, List<ChannelInstance> inputChannelInstances);
+    protected abstract void open(ExecutionTask task,
+                                 List<ChannelInstance> inputChannelInstances,
+                                 OptimizationContext.OperatorContext operatorContext);
 
     /**
      * Executes the given {@code task} and return the output {@link ChannelInstance}s.
@@ -173,8 +176,9 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
 
     /**
      * Marks all unproduced {@link ChannelInstance}s in a lineage and collects them in a {@link Collection}.
+     *
      * @param channelInstance that should be marked and collected - including its predecessors
-     * @param collector collects the marked {@link ChannelInstance}s
+     * @param collector       collects the marked {@link ChannelInstance}s
      */
     private void markAndAddUnproducedChannelInstances(
             ChannelInstance channelInstance,

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
@@ -51,9 +51,6 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
      * @return the output {@link ChannelInstance}s of the {@link ExecutionTask}
      */
     private Tuple<List<ChannelInstance>, PartialExecution> execute(TaskActivator taskActivator, boolean isForceExecution) {
-        // Execute the ExecutionTask.
-        this.open(taskActivator.getTask(), taskActivator.getInputChannelInstances(), taskActivator.getOperatorContext());
-
         return this.execute(
                 taskActivator.getTask(),
                 taskActivator.getInputChannelInstances(),
@@ -86,18 +83,6 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
         }
         return channelInstances;
     }
-
-    /**
-     * Prepares the given {@code task} for execution.
-     *
-     * @param task                  that should be executed
-     * @param inputChannelInstances inputs into the {@code task}
-     * @param operatorContext       contains optimization information on the wrapped {@link ExecutionOperator}
-     * @return the {@link ChannelInstance}s created as output of {@code task}
-     */
-    protected abstract void open(ExecutionTask task,
-                                 List<ChannelInstance> inputChannelInstances,
-                                 OptimizationContext.OperatorContext operatorContext);
 
     /**
      * Executes the given {@code task} and return the output {@link ChannelInstance}s.

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/execution/JavaExecutionContext.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/execution/JavaExecutionContext.java
@@ -19,9 +19,12 @@ public class JavaExecutionContext implements ExecutionContext {
 
     private final ChannelInstance[] inputs;
 
-    public JavaExecutionContext(JavaExecutionOperator operator, ChannelInstance[] inputs) {
+    private final int iterationNumber;
+
+    public JavaExecutionContext(JavaExecutionOperator operator, ChannelInstance[] inputs, int iterationNumber) {
         this.operator = operator;
         this.inputs = inputs;
+        this.iterationNumber = iterationNumber;
     }
 
     @Override
@@ -36,5 +39,10 @@ public class JavaExecutionContext implements ExecutionContext {
         }
 
         throw new RheemException("No such broadcast found: " + name);
+    }
+
+    @Override
+    public int getCurrentIteration() {
+        return this.iterationNumber;
     }
 }

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/execution/JavaExecutor.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/execution/JavaExecutor.java
@@ -11,9 +11,9 @@ import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.PartialExecution;
 import org.qcri.rheem.core.platform.PushExecutorTemplate;
 import org.qcri.rheem.core.util.Tuple;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
+import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,13 +36,6 @@ public class JavaExecutor extends PushExecutorTemplate {
     @Override
     public JavaPlatform getPlatform() {
         return this.platform;
-    }
-
-    @Override
-    protected void open(ExecutionTask task,
-                                 List<ChannelInstance> inputChannelInstances,
-                                 OptimizationContext.OperatorContext operatorContext) {
-        cast(task.getOperator()).open(toArray(inputChannelInstances), operatorContext, this.compiler);
     }
 
     @Override
@@ -101,6 +94,14 @@ public class JavaExecutor extends PushExecutorTemplate {
         return channelInstances.toArray(array);
     }
 
+    /**
+     * Utility function to open an {@link ExtendedFunction}.
+     *
+     * @param operator        the {@link JavaExecutionOperator} containing the function
+     * @param function        the {@link ExtendedFunction}; if it is of a different type, nothing happens
+     * @param inputs          the input {@link ChannelInstance}s for the {@code operator}
+     * @param operatorContext context information for the {@code operator}
+     */
     public static void openFunction(JavaExecutionOperator operator,
                                     Object function,
                                     ChannelInstance[] inputs,

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCartesianOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCartesianOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.CartesianOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +13,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -43,7 +44,10 @@ public class JavaCartesianOperator<InputType0, InputType1>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         if (inputs.length != 2) {
             throw new IllegalArgumentException("Cannot evaluate: Illegal number of input streams.");
         }

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCollectOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCollectOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.apache.commons.lang3.Validate;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimator;
 import org.qcri.rheem.core.optimizer.cardinality.DefaultCardinalityEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
@@ -12,7 +13,7 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,10 @@ public class JavaCollectOperator<Type> extends UnaryToUnaryOperator<Type, Type> 
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         final StreamChannel.Instance streamChannelInstance = (StreamChannel.Instance) inputs[0];
         final CollectionChannel.Instance collectionChannelInstance = (CollectionChannel.Instance) outputs[0];
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCollectionSource.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCollectionSource.java
@@ -3,8 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.CollectionSource;
 import org.qcri.rheem.basic.operators.TextFileSource;
 import org.qcri.rheem.core.api.Configuration;
-import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
-import org.qcri.rheem.core.optimizer.costs.LoadEstimator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +11,7 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +38,10 @@ public class JavaCollectionSource<T> extends CollectionSource<T> implements Java
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == 0;
         assert outputs.length == 1;
         ((CollectionChannel.Instance) outputs[0]).accept(this.getCollection());

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCountOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaCountOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.CountOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -11,7 +12,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +46,10 @@ public class JavaCountOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDistinctOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDistinctOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.DistinctOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -11,7 +12,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +46,10 @@ public class JavaDistinctOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDoWhileOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDoWhileOperator.java
@@ -13,7 +13,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
@@ -52,14 +51,6 @@ public class JavaDoWhileOperator<InputType, ConvergenceType>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final Predicate<Collection<ConvergenceType>> udf = compiler.compile(this.criterionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public void evaluate(ChannelInstance[] inputs,
                          ChannelInstance[] outputs,
@@ -70,6 +61,8 @@ public class JavaDoWhileOperator<InputType, ConvergenceType>
 
         final Predicate<Collection<ConvergenceType>> stoppingCondition =
                 javaExecutor.getCompiler().compile(this.criterionDescriptor);
+        JavaExecutor.openFunction(this, stoppingCondition, inputs, operatorContext);
+
         boolean endloop = false;
 
         final Collection<ConvergenceType> convergenceCollection;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDoWhileOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaDoWhileOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.DoWhileOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.function.PredicateDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -51,18 +52,24 @@ public class JavaDoWhileOperator<InputType, ConvergenceType>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs, FunctionCompiler compiler) {
+    public void open(ChannelInstance[] inputs,
+                     OptimizationContext.OperatorContext operatorContext,
+                     FunctionCompiler compiler) {
         final Predicate<Collection<ConvergenceType>> udf = compiler.compile(this.criterionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs);
+        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final Predicate<Collection<ConvergenceType>> stoppingCondition = compiler.compile(this.criterionDescriptor);
+        final Predicate<Collection<ConvergenceType>> stoppingCondition =
+                javaExecutor.getCompiler().compile(this.criterionDescriptor);
         boolean endloop = false;
 
         final Collection<ConvergenceType> convergenceCollection;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaExecutionOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaExecutionOperator.java
@@ -1,11 +1,12 @@
 package org.qcri.rheem.java.operators;
 
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.ChannelInstance;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
+import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.util.stream.Stream;
 
@@ -22,10 +23,13 @@ public interface JavaExecutionOperator extends ExecutionOperator {
     /**
      * When this instance is not yet initialized, this method is called.
      *
-     * @param inputs   {@link JavaChannelInstance}s that satisfy the inputs of this operator
-     * @param compiler compiles functions used by this instance
+     * @param inputs          {@link JavaChannelInstance}s that satisfy the inputs of this operator
+     * @param operatorContext contains optimization information for this instance
+     * @param compiler        compiles functions used by this instance
      */
-    default void open(ChannelInstance[] inputs, FunctionCompiler compiler) {
+    default void open(ChannelInstance[] inputs,
+                      OptimizationContext.OperatorContext operatorContext,
+                      FunctionCompiler compiler) {
         // Do nothing by default.
     }
 
@@ -34,23 +38,14 @@ public interface JavaExecutionOperator extends ExecutionOperator {
      * a set of {@link Stream}s according to the operator outputs -- unless the operator is a sink, then it triggers
      * execution.
      *
-     * @param inputs   {@link ChannelInstance}s that satisfy the inputs of this operator
-     * @param outputs  {@link ChannelInstance}s that collect the outputs of this operator
-     * @param compiler compiles functions used by the operator
+     * @param inputs          {@link ChannelInstance}s that satisfy the inputs of this operator
+     * @param outputs         {@link ChannelInstance}s that collect the outputs of this operator
+     * @param javaExecutor    that executes this instance
+     * @param operatorContext optimization information for this instance
      */
-    void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler);
-
-    /**
-     * Evaluates this operator. Takes a set of Java {@link Stream}s according to the operator inputs and produces
-     * a set of {@link Stream}s according to the operator outputs -- unless the operator is a sink, then it triggers
-     * execution.
-     *
-     * @param inputs       {@link ChannelInstance}s that satisfy the inputs of this operator
-     * @param outputs      {@link ChannelInstance}s that collect the outputs of this operator
-     * @param javaExecutor that executes this instance
-     */
-    default void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, JavaExecutor javaExecutor) {
-        this.evaluate(inputs, outputs, javaExecutor.getCompiler());
-    }
+    void evaluate(ChannelInstance[] inputs,
+                  ChannelInstance[] outputs,
+                  JavaExecutor javaExecutor,
+                  OptimizationContext.OperatorContext operatorContext);
 
 }

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaExecutionOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaExecutionOperator.java
@@ -3,8 +3,6 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.ChannelInstance;
-import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.platform.JavaPlatform;
 
@@ -18,19 +16,6 @@ public interface JavaExecutionOperator extends ExecutionOperator {
     @Override
     default JavaPlatform getPlatform() {
         return JavaPlatform.getInstance();
-    }
-
-    /**
-     * When this instance is not yet initialized, this method is called.
-     *
-     * @param inputs          {@link JavaChannelInstance}s that satisfy the inputs of this operator
-     * @param operatorContext contains optimization information for this instance
-     * @param compiler        compiles functions used by this instance
-     */
-    default void open(ChannelInstance[] inputs,
-                      OptimizationContext.OperatorContext operatorContext,
-                      FunctionCompiler compiler) {
-        // Do nothing by default.
     }
 
     /**

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaFilterOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaFilterOperator.java
@@ -13,7 +13,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
@@ -39,14 +38,6 @@ public class JavaFilterOperator<Type>
         super(predicateDescriptor, type);
     }
 
-    @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final Predicate<Type> filterFunction = compiler.compile(this.predicateDescriptor);
-        JavaExecutor.openFunction(this, filterFunction, inputs, operatorContext);
-    }
-
     public JavaFilterOperator(DataSetType<Type> type, PredicateDescriptor.SerializablePredicate<Type> predicateDescriptor) {
         super(type, predicateDescriptor);
     }
@@ -70,6 +61,7 @@ public class JavaFilterOperator<Type>
         assert outputs.length == this.getNumOutputs();
 
         final Predicate<Type> filterFunction = javaExecutor.getCompiler().compile(this.predicateDescriptor);
+        JavaExecutor.openFunction(this, filterFunction, inputs, operatorContext);
         ((StreamChannel.Instance) outputs[0]).accept(((JavaChannelInstance) inputs[0]).<Type>provideStream().filter(filterFunction));
     }
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaFlatMapOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaFlatMapOperator.java
@@ -13,7 +13,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
@@ -44,14 +43,6 @@ public class JavaFlatMapOperator<InputType, OutputType>
      */
     public JavaFlatMapOperator(FlatMapOperator<InputType, OutputType> that) {
         super(that);
-    }
-
-    @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final Function<InputType, Iterable<OutputType>> udf = compiler.compile(this.functionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalMaterializedGroupOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalMaterializedGroupOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.GlobalMaterializedGroupOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,12 +10,12 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 
 /**
- * TODO
+ * Java implementation of the {@link GlobalMaterializedGroupOperator}.
  */
 public class JavaGlobalMaterializedGroupOperator<Type>
         extends GlobalMaterializedGroupOperator<Type>
@@ -38,7 +39,10 @@ public class JavaGlobalMaterializedGroupOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == 1;
         assert outputs.length == 1;
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperator.java
@@ -3,8 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.GlobalReduceOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.function.ReduceDescriptor;
-import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
-import org.qcri.rheem.core.optimizer.costs.LoadEstimator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -53,18 +52,23 @@ public class JavaGlobalReduceOperator<Type>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs, FunctionCompiler compiler) {
+    public void open(ChannelInstance[] inputs,
+                     OptimizationContext.OperatorContext operatorContext,
+                     FunctionCompiler compiler) {
         final BiFunction<Type, Type, Type> udf = compiler.compile(this.reduceDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs);
+        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final BinaryOperator<Type> reduceFunction = compiler.compile(this.reduceDescriptor);
-        JavaExecutor.openFunction(this, reduceFunction, inputs);
+        final BinaryOperator<Type> reduceFunction = javaExecutor.getCompiler().compile(this.reduceDescriptor);
+        JavaExecutor.openFunction(this, reduceFunction, inputs, operatorContext);
 
         final Optional<Type> reduction = ((JavaChannelInstance) inputs[0]).<Type>provideStream().reduce(reduceFunction);
         ((CollectionChannel.Instance) outputs[0]).accept(reduction.isPresent() ?

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperator.java
@@ -13,14 +13,12 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 
 /**
@@ -49,14 +47,6 @@ public class JavaGlobalReduceOperator<Type>
      */
     public JavaGlobalReduceOperator(GlobalReduceOperator<Type> that) {
         super(that);
-    }
-
-    @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final BiFunction<Type, Type, Type> udf = compiler.compile(this.reduceDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaIntersectOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaIntersectOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.IntersectOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
@@ -12,7 +13,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -43,7 +44,10 @@ public class JavaIntersectOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
@@ -76,6 +80,7 @@ public class JavaIntersectOperator<Type>
 
     /**
      * Creates a new probing table. The can be altered then.
+     *
      * @param stream for that the probing table should be created
      * @return the probing table
      */

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaJoinOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaJoinOperator.java
@@ -4,6 +4,7 @@ import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.JoinOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
@@ -14,7 +15,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 import java.util.function.Function;
@@ -48,12 +49,15 @@ public class JavaJoinOperator<InputType0, InputType1, KeyType>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final Function<InputType0, KeyType> keyExtractor0 = compiler.compile(this.keyDescriptor0);
-        final Function<InputType1, KeyType> keyExtractor1 = compiler.compile(this.keyDescriptor1);
+        final Function<InputType0, KeyType> keyExtractor0 = javaExecutor.getCompiler().compile(this.keyDescriptor0);
+        final Function<InputType1, KeyType> keyExtractor1 = javaExecutor.getCompiler().compile(this.keyDescriptor1);
 
         final CardinalityEstimate cardinalityEstimate0 = this.getInput(0).getCardinalityEstimate();
         final CardinalityEstimate cardinalityEstimate1 = this.getInput(0).getCardinalityEstimate();

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLocalCallbackSink.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLocalCallbackSink.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.LocalCallbackSink;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,6 +13,7 @@ import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
 import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +44,10 @@ public class JavaLocalCallbackSink<T> extends LocalCallbackSink<T> implements Ja
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor executor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLoopOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLoopOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.LoopOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.function.PredicateDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -53,18 +54,23 @@ public class JavaLoopOperator<InputType, ConvergenceType>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs, FunctionCompiler compiler) {
+    public void open(ChannelInstance[] inputs,
+                     OptimizationContext.OperatorContext operatorContext,
+                     FunctionCompiler compiler) {
         final Predicate<Collection<ConvergenceType>> udf = compiler.compile(this.criterionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs);
+        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final Predicate<Collection<ConvergenceType>> stoppingCondition = compiler.compile(this.criterionDescriptor);
+        final Predicate<Collection<ConvergenceType>> stoppingCondition = javaExecutor.getCompiler().compile(this.criterionDescriptor);
         boolean endloop = false;
 
         final Collection<ConvergenceType> convergenceCollection;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLoopOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaLoopOperator.java
@@ -13,7 +13,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
@@ -54,14 +53,6 @@ public class JavaLoopOperator<InputType, ConvergenceType>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final Predicate<Collection<ConvergenceType>> udf = compiler.compile(this.criterionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public void evaluate(ChannelInstance[] inputs,
                          ChannelInstance[] outputs,
@@ -70,7 +61,9 @@ public class JavaLoopOperator<InputType, ConvergenceType>
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final Predicate<Collection<ConvergenceType>> stoppingCondition = javaExecutor.getCompiler().compile(this.criterionDescriptor);
+        final Predicate<Collection<ConvergenceType>> stoppingCondition =
+                javaExecutor.getCompiler().compile(this.criterionDescriptor);
+        JavaExecutor.openFunction(this, stoppingCondition, inputs, operatorContext);
         boolean endloop = false;
 
         final Collection<ConvergenceType> convergenceCollection;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaMapOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaMapOperator.java
@@ -13,7 +13,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
@@ -46,14 +45,6 @@ public class JavaMapOperator<InputType, OutputType>
     }
 
     @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final Function<InputType, OutputType> udf = compiler.compile(this.functionDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
-    }
-
-    @Override
     public void evaluate(ChannelInstance[] inputs,
                          ChannelInstance[] outputs,
                          JavaExecutor javaExecutor,
@@ -63,7 +54,6 @@ public class JavaMapOperator<InputType, OutputType>
 
         final Function<InputType, OutputType> function = javaExecutor.getCompiler().compile(this.functionDescriptor);
         JavaExecutor.openFunction(this, function, inputs, operatorContext);
-
         ((StreamChannel.Instance) outputs[0]).accept(((JavaChannelInstance) inputs[0]).<InputType>provideStream().map(function));
     }
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaMaterializedGroupByOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaMaterializedGroupByOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.MaterializedGroupByOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,6 +14,7 @@ import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
 import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 import java.util.function.Function;
@@ -42,11 +44,14 @@ public class JavaMaterializedGroupByOperator<Type, KeyType>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        final Function<Type, KeyType> keyExtractor = compiler.compile(this.keyDescriptor);
+        final Function<Type, KeyType> keyExtractor = javaExecutor.getCompiler().compile(this.keyDescriptor);
         final Map<KeyType, List<Type>> collocation = ((JavaChannelInstance) inputs[0]).<Type>provideStream().collect(
                 Collectors.groupingBy(
                         keyExtractor,

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaObjectFileSink.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaObjectFileSink.java
@@ -8,6 +8,7 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -16,11 +17,11 @@ import org.qcri.rheem.core.plan.rheemplan.UnarySink;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -45,18 +46,22 @@ public class JavaObjectFileSink<T> extends UnarySink<T> implements JavaExecution
     public JavaObjectFileSink(DataSetType<T> type) {
         this(null, type);
     }
+
     public JavaObjectFileSink(String targetPath, DataSetType<T> type) {
         super(type);
         this.targetPath = targetPath;
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
 
         // Prepare Hadoop's SequenceFile.Writer.
         FileChannel.Instance output = (FileChannel.Instance) outputs[0];
-        final String path = output.addGivenOrTempPath(this.targetPath, compiler.getConfiguration());
+        final String path = output.addGivenOrTempPath(this.targetPath, javaExecutor.getCompiler().getConfiguration());
 
         final SequenceFile.Writer.Option fileOption = SequenceFile.Writer.file(new Path(path));
         final SequenceFile.Writer.Option keyClassOption = SequenceFile.Writer.keyClass(NullWritable.class);

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaObjectFileSource.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaObjectFileSource.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -19,7 +20,7 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.platform.JavaPlatform;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,10 @@ public class JavaObjectFileSource<T> extends UnarySource<T> implements JavaExecu
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert outputs.length == this.getNumOutputs();
 
         SequenceFileIterator sequenceFileIterator;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.SampleOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
@@ -13,7 +14,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -57,7 +58,10 @@ public class JavaRandomSampleOperator<Type>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReduceByOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReduceByOperator.java
@@ -14,11 +14,13 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
-import java.util.function.*;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -49,14 +51,6 @@ public class JavaReduceByOperator<Type, KeyType>
      */
     public JavaReduceByOperator(ReduceByOperator<Type, KeyType> that) {
         super(that);
-    }
-
-    @Override
-    public void open(ChannelInstance[] inputs,
-                     OptimizationContext.OperatorContext operatorContext,
-                     FunctionCompiler compiler) {
-        final BiFunction<Type, Type, Type> udf = compiler.compile(this.reduceDescriptor);
-        JavaExecutor.openFunction(this, udf, inputs, operatorContext);
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRepeatOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRepeatOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.DoWhileOperator;
 import org.qcri.rheem.basic.operators.RepeatOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +13,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +45,10 @@ public class JavaRepeatOperator<Type>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.SampleOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
@@ -13,7 +14,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.*;
 
@@ -56,7 +57,10 @@ public class JavaReservoirSampleOperator<Type>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaSortOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaSortOperator.java
@@ -2,8 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.SortOperator;
 import org.qcri.rheem.core.api.Configuration;
-import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
-import org.qcri.rheem.core.optimizer.costs.LoadEstimator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,7 +12,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,7 +46,10 @@ public class JavaSortOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTextFileSink.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTextFileSink.java
@@ -3,12 +3,13 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.TextFileSink;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.util.fs.FileSystem;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.io.BufferedWriter;
@@ -33,13 +34,16 @@ public class JavaTextFileSink<T> extends TextFileSink<T> implements JavaExecutio
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == 1;
         assert outputs.length == 0;
 
         StreamChannel.Instance input = (StreamChannel.Instance) inputs[0];
         final FileSystem fs = FileSystems.requireFileSystem(this.textFileUrl);
-        final Function<T, String> formatter = compiler.compile(this.formattingDescriptor);
+        final Function<T, String> formatter = javaExecutor.getCompiler().compile(this.formattingDescriptor);
 
 
         try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(fs.create(this.textFileUrl)))) {

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTextFileSource.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTextFileSource.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.operators;
 import org.qcri.rheem.basic.operators.TextFileSource;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
@@ -10,7 +11,7 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.util.fs.FileSystem;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -42,7 +43,10 @@ public class JavaTextFileSource extends TextFileSource implements JavaExecutionO
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTsvFileSink.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTsvFileSink.java
@@ -4,6 +4,7 @@ import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -18,6 +19,7 @@ import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
 import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.io.BufferedWriter;
@@ -51,12 +53,15 @@ public class JavaTsvFileSink<T extends Tuple2<?, ?>> extends UnarySink<T> implem
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
 
         // Prepare Hadoop's SequenceFile.Writer.
         FileChannel.Instance output = (FileChannel.Instance) outputs[0];
-        final String path = output.addGivenOrTempPath(this.targetPath, compiler.getConfiguration());
+        final String path = output.addGivenOrTempPath(this.targetPath, javaExecutor.getCompiler().getConfiguration());
         final FileSystem fileSystem = FileSystems.getFileSystem(path).orElseThrow(
                 () -> new IllegalStateException(String.format("No file system found for \"%s\".", this.targetPath))
         );

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTsvFileSource.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaTsvFileSource.java
@@ -5,6 +5,7 @@ import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.basic.data.Record;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -16,7 +17,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.fs.FileSystem;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.io.BufferedReader;
@@ -47,7 +48,10 @@ public class JavaTsvFileSource<T> extends UnarySource<T> implements JavaExecutio
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert outputs.length == this.getNumOutputs();
 
         final String path;

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaUnionAllOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaUnionAllOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.java.operators;
 
 import org.qcri.rheem.basic.operators.UnionAllOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -11,7 +12,7 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +46,10 @@ public class JavaUnionAllOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/graph/JavaPageRankOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/graph/JavaPageRankOperator.java
@@ -7,11 +7,12 @@ import gnu.trove.map.hash.TLongFloatHashMap;
 import gnu.trove.map.hash.TLongIntHashMap;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.PageRankOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.StreamChannel;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 
 import java.util.*;
@@ -32,7 +33,10 @@ public class JavaPageRankOperator extends PageRankOperator implements JavaExecut
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor javaExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         CollectionChannel.Instance input = (CollectionChannel.Instance) inputs[0];
         StreamChannel.Instance output = (StreamChannel.Instance) outputs[0];
 

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCartesianOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCartesianOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +34,7 @@ public class JavaCartesianOperatorTest extends JavaExecutionOperatorTestBase {
                 createStreamChannelInstance(inputStream1)
         };
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        cartesianOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(cartesianOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Tuple2<Integer, String>> result = outputs[0].<Tuple2<Integer, String>>provideStream()

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCollectionSourceTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCollectionSourceTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -25,7 +24,7 @@ public class JavaCollectionSourceTest extends JavaExecutionOperatorTestBase {
         JavaChannelInstance[] inputs = new JavaChannelInstance[0];
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
 
-        collectionSource.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(collectionSource, inputs, outputs);
 
         final Set<Object> outputValues = outputs[0].provideStream().collect(Collectors.toSet());
         Assert.assertEquals(outputValues, inputValues);

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCountOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaCountOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +29,7 @@ public class JavaCountOperatorTest extends JavaExecutionOperatorTestBase {
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        countOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(countOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaDistinctOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaDistinctOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +29,7 @@ public class JavaDistinctOperatorTest extends JavaExecutionOperatorTestBase {
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        distinctOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(distinctOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaExecutionOperatorTestBase.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaExecutionOperatorTestBase.java
@@ -2,12 +2,22 @@ package org.qcri.rheem.java.operators;
 
 import org.junit.BeforeClass;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.api.Job;
+import org.qcri.rheem.core.optimizer.DefaultOptimizationContext;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.plan.rheemplan.Operator;
+import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.StreamChannel;
+import org.qcri.rheem.java.execution.JavaExecutor;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.test.ChannelFactory;
 
 import java.util.Collection;
 import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Superclass for tests of {@link JavaExecutionOperator}s.
@@ -19,6 +29,23 @@ public class JavaExecutionOperatorTestBase {
     @BeforeClass
     public static void init() {
         configuration = new Configuration();
+    }
+
+    protected static JavaExecutor createExecutor() {
+        final Job job = mock(Job.class);
+        when(job.getConfiguration()).thenReturn(configuration);
+        return new JavaExecutor(JavaPlatform.getInstance(), job);
+    }
+
+    protected static OptimizationContext.OperatorContext createOperatorContext(Operator operator) {
+        OptimizationContext optimizationContext = new DefaultOptimizationContext(configuration);
+        return optimizationContext.addOneTimeOperator(operator);
+    }
+
+    protected static void evaluate(JavaExecutionOperator operator,
+                                   ChannelInstance[] inputs,
+                                   ChannelInstance[] outputs) {
+        operator.evaluate(inputs, outputs, createExecutor(), createOperatorContext(operator));
     }
 
     protected static StreamChannel.Instance createStreamChannelInstance() {

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaFilterOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaFilterOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.function.PredicateDescriptor;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +30,7 @@ public class JavaFilterOperatorTest extends JavaExecutionOperatorTestBase {
 
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        filterOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(filterOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaGlobalMaterializedGroupOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaGlobalMaterializedGroupOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,7 +30,7 @@ public class JavaGlobalMaterializedGroupOperatorTest extends JavaExecutionOperat
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createCollectionChannelInstance(inputCollection)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        globalGroup.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(globalGroup, inputs, outputs);
 
         // Verify the outcome.
         final Collection<Collection<Integer>> result = ((CollectionChannel.Instance) outputs[0]).provideCollection();
@@ -55,7 +54,7 @@ public class JavaGlobalMaterializedGroupOperatorTest extends JavaExecutionOperat
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createCollectionChannelInstance(inputCollection)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        globalGroup.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(globalGroup, inputs, outputs);
 
         // Verify the outcome.
         final Collection<Collection<Integer>> result = ((CollectionChannel.Instance) outputs[0]).provideCollection();

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaGlobalReduceOperatorTest.java
@@ -7,7 +7,6 @@ import org.qcri.rheem.core.function.ReduceDescriptor;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +36,7 @@ public class JavaGlobalReduceOperatorTest extends JavaExecutionOperatorTestBase 
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        globalReduce.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(globalReduce, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());
@@ -64,7 +63,7 @@ public class JavaGlobalReduceOperatorTest extends JavaExecutionOperatorTestBase 
         // Execute the reduce operator.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        globalReduce.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(globalReduce, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaJoinOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaJoinOperatorTest.java
@@ -7,7 +7,6 @@ import org.qcri.rheem.basic.function.ProjectionDescriptor;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,7 +49,7 @@ public class JavaJoinOperatorTest extends JavaExecutionOperatorTestBase {
                 createStreamChannelInstance(inputStream1)
         };
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        join.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(join, inputs, outputs);
 
         // Verify the outcome.
         final List<Tuple2<Tuple2<Integer, String>, Tuple2<String, Integer>>> result =

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaLocalCallbackSinkTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaLocalCallbackSinkTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -27,7 +26,7 @@ public class JavaLocalCallbackSinkTest extends JavaExecutionOperatorTestBase {
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createCollectionChannelInstance(inputValues)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{};
-        sink.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(sink, inputs, outputs);
 
         // Verify the outcome.
         Assert.assertEquals(collector, inputValues);

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaMaterializedGroupByOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaMaterializedGroupByOperatorTest.java
@@ -7,7 +7,6 @@ import org.qcri.rheem.basic.function.ProjectionDescriptor;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +40,7 @@ public class JavaMaterializedGroupByOperatorTest extends JavaExecutionOperatorTe
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
-        collocateByOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(collocateByOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Tuple2<String, Integer>> result = outputs[0].<Tuple2<String, Integer>>provideStream()

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaObjectFileSinkTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaObjectFileSinkTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -37,7 +36,7 @@ public class JavaObjectFileSinkTest extends JavaExecutionOperatorTestBase {
                 .createChannel(null, configuration)
                 .createInstance(null, null, -1);
         ChannelInstance[] outputs = new ChannelInstance[]{outputChannel};
-        sink.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(sink, inputs, outputs);
     }
 
     static List<Integer> enumerateRange(int to) {

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaObjectFileSourceTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaObjectFileSourceTest.java
@@ -5,7 +5,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.execution.JavaExecutor;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ public class JavaObjectFileSourceTest extends JavaExecutionOperatorTestBase {
             // Execute.
             JavaChannelInstance[] inputs = new JavaChannelInstance[]{};
             JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-            source.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+            evaluate(source, inputs, outputs);
 
             // Verify.
             Set<Integer> expectedValues = new HashSet<>(JavaObjectFileSourceTest.enumerateRange(10000));

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaRandomSampleOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaRandomSampleOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class JavaRandomSampleOperatorTest extends JavaExecutionOperatorTestBase 
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
 
         // Execute.
-        sampleOperator.evaluate(inputs, outputs, (FunctionCompiler) null);
+        evaluate(sampleOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaReduceByOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaReduceByOperatorTest.java
@@ -8,7 +8,6 @@ import org.qcri.rheem.core.function.ReduceDescriptor;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -46,7 +45,7 @@ public class JavaReduceByOperatorTest extends JavaExecutionOperatorTestBase {
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
 
         // Execute the reduce operator.
-        reduceByOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(reduceByOperator, inputs, outputs);
 
         // Verify the outcome.
         final Set<Tuple2<String, Integer>> result =

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class JavaReservoirSampleOperatorTest extends JavaExecutionOperatorTestBa
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createCollectionChannelInstance()};
 
         // Execute.
-        sampleOperator.evaluate(inputs, outputs, (FunctionCompiler) null);
+        evaluate(sampleOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaSortOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaSortOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +29,7 @@ public class JavaSortOperatorTest extends JavaExecutionOperatorTestBase {
         // Execute.
         JavaChannelInstance[] inputs = new JavaChannelInstance[]{createStreamChannelInstance(inputStream)};
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        sortOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(sortOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaTextFileSinkTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaTextFileSinkTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test suite for {@link JavaTextFileSink}.
  */
-public class JavaTextFileSinkTest {
+public class JavaTextFileSinkTest extends JavaExecutionOperatorTestBase {
 
     @Test
     public void testWritingLocalFile() throws IOException, URISyntaxException {
@@ -54,11 +54,8 @@ public class JavaTextFileSinkTest {
                 .createChannel(mock(OutputSlot.class), configuration)
                 .createInstance(javaExecutor, mock(OptimizationContext.OperatorContext.class), 0);
         inputChannelInstance.accept(Stream.of(1.123f, -0.1f, 3f));
-        sink.evaluate(
-                new ChannelInstance[]{inputChannelInstance},
-                new ChannelInstance[]{},
-                javaExecutor
-        );
+        evaluate(sink, new ChannelInstance[]{inputChannelInstance}, new ChannelInstance[0]);
+
 
         final List<String> lines = Files.lines(Paths.get(new URI(targetUrl))).collect(Collectors.toList());
         Assert.assertEquals(

--- a/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaUnionAllOperatorTest.java
+++ b/rheem-platforms/rheem-java/src/test/java/org/qcri/rheem/java/operators/JavaUnionAllOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,7 +31,7 @@ public class JavaUnionAllOperatorTest extends JavaExecutionOperatorTestBase {
                 createStreamChannelInstance(inputStream1)
         };
         JavaChannelInstance[] outputs = new JavaChannelInstance[]{createStreamChannelInstance()};
-        unionAllOperator.evaluate(inputs, outputs, new FunctionCompiler(configuration));
+        evaluate(unionAllOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = outputs[0].<Integer>provideStream()

--- a/rheem-platforms/rheem-jdbc-template/src/main/java/org.qcri.rheem.jdbc/operators/SqlToStreamOperator.java
+++ b/rheem-platforms/rheem-jdbc-template/src/main/java/org.qcri.rheem.jdbc/operators/SqlToStreamOperator.java
@@ -4,6 +4,7 @@ import org.qcri.rheem.basic.data.Record;
 import org.qcri.rheem.basic.types.RecordType;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.Operator;
@@ -59,7 +60,10 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, JavaExecutor executor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         JavaExecutor executor,
+                         OptimizationContext.OperatorContext operatorContext) {
         // Cast the inputs and outputs.
         final SqlQueryChannel.Instance input = (SqlQueryChannel.Instance) inputs[0];
         final StreamChannel.Instance output = (StreamChannel.Instance) outputs[0];
@@ -74,11 +78,6 @@ public class SqlToStreamOperator extends UnaryToUnaryOperator<Record, Record> im
         Stream<Record> resultSetStream = StreamSupport.stream(resultSetSpliterator, false);
 
         output.accept(resultSetStream);
-    }
-
-    @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler) {
-        throw new RheemException("This method should not be called.");
     }
 
     @Override

--- a/rheem-platforms/rheem-jdbc-template/src/test/java/org/qcri/rheem/jdbc/operators/SqlToStreamOperatorTest.java
+++ b/rheem-platforms/rheem-jdbc-template/src/test/java/org/qcri/rheem/jdbc/operators/SqlToStreamOperatorTest.java
@@ -13,9 +13,9 @@ import org.qcri.rheem.core.plan.rheemplan.OutputSlot;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.platform.CrossPlatformExecutor;
 import org.qcri.rheem.core.profiling.FullInstrumentationStrategy;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.channels.StreamChannel;
 import org.qcri.rheem.java.execution.JavaExecutor;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.jdbc.channels.SqlQueryChannel;
 import org.qcri.rheem.jdbc.test.HsqldbFilterOperator;
 import org.qcri.rheem.jdbc.test.HsqldbPlatform;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test suite for {@link SqlToStreamOperator}.
  */
-public class SqlToStreamOperatorTest {
+public class SqlToStreamOperatorTest extends OperatorTestBase {
 
     @Test
     public void testWithHsqldb() throws SQLException {
@@ -81,10 +81,10 @@ public class SqlToStreamOperatorTest {
                 );
 
         SqlToStreamOperator sqlToStreamOperator = new SqlToStreamOperator(HsqldbPlatform.getInstance());
-        sqlToStreamOperator.evaluate(
-                new ChannelInstance[] { sqlQueryChannelInstance },
-                new ChannelInstance[] { streamChannelInstance },
-                javaExecutor
+        evaluate(
+                sqlToStreamOperator,
+                new ChannelInstance[]{sqlQueryChannelInstance},
+                new ChannelInstance[]{streamChannelInstance}
         );
 
         List<Record> output = streamChannelInstance.<Record>provideStream().collect(Collectors.toList());
@@ -140,10 +140,10 @@ public class SqlToStreamOperatorTest {
                 );
 
         SqlToStreamOperator sqlToStreamOperator = new SqlToStreamOperator(HsqldbPlatform.getInstance());
-        sqlToStreamOperator.evaluate(
-                new ChannelInstance[] { sqlQueryChannelInstance },
-                new ChannelInstance[] { streamChannelInstance },
-                javaExecutor
+        evaluate(
+                sqlToStreamOperator,
+                new ChannelInstance[]{sqlQueryChannelInstance},
+                new ChannelInstance[]{streamChannelInstance}
         );
 
         List<Record> output = streamChannelInstance.<Record>provideStream().collect(Collectors.toList());

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/execution/SparkExecutionContext.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/execution/SparkExecutionContext.java
@@ -19,6 +19,14 @@ import java.util.Map;
  */
 public class SparkExecutionContext implements ExecutionContext, Serializable {
 
+    /**
+     * Iteration number of the execution.
+     */
+    private int iterationNumber;
+
+    /**
+     * Mapping of broadcast name to {@link Broadcast} references.
+     */
     private Map<String, Broadcast<?>> broadcasts;
 
     /**
@@ -27,7 +35,7 @@ public class SparkExecutionContext implements ExecutionContext, Serializable {
      * @param operator {@link SparkExecutionOperator} for that the instance should be created
      * @param inputs   {@link ChannelInstance} inputs for the {@code operator}
      */
-    public SparkExecutionContext(SparkExecutionOperator operator, ChannelInstance[] inputs) {
+    public SparkExecutionContext(SparkExecutionOperator operator, ChannelInstance[] inputs, int iterationNumber) {
         this.broadcasts = new HashMap<>();
         for (int inputIndex = 0; inputIndex < operator.getNumInputs(); inputIndex++) {
             InputSlot<?> inputSlot = operator.getInput(inputIndex);
@@ -36,6 +44,7 @@ public class SparkExecutionContext implements ExecutionContext, Serializable {
                 this.broadcasts.put(inputSlot.getName(), broadcastChannelInstance.provideBroadcast());
             }
         }
+        this.iterationNumber = iterationNumber;
     }
 
     /**
@@ -54,5 +63,10 @@ public class SparkExecutionContext implements ExecutionContext, Serializable {
         }
 
         return (Collection<T>) broadcast.getValue();
+    }
+
+    @Override
+    public int getCurrentIteration() {
+        return this.iterationNumber;
     }
 }

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/execution/SparkExecutor.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/execution/SparkExecutor.java
@@ -66,13 +66,6 @@ public class SparkExecutor extends PushExecutorTemplate {
     }
 
     @Override
-    protected void open(ExecutionTask task,
-                        List<ChannelInstance> inputChannelInstances,
-                        OptimizationContext.OperatorContext operatorContext) {
-        // Nothing to do. Opening is handled in #execute(...).
-    }
-
-    @Override
     protected Tuple<List<ChannelInstance>, PartialExecution> execute(ExecutionTask task,
                                                                      List<ChannelInstance> inputChannelInstances,
                                                                      OptimizationContext.OperatorContext producerOperatorContext,

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.SampleOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
@@ -11,7 +12,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.BroadcastChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -57,7 +57,10 @@ public class SparkBernoulliSampleOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
@@ -68,7 +71,7 @@ public class SparkBernoulliSampleOperator<Type>
 
         final JavaRDD<Type> inputRdd = input.provideRdd();
         if (datasetSize > 0) //sample size was given as input
-            sampleFraction = ((double)sampleSize) / datasetSize;
+            sampleFraction = ((double) sampleSize) / datasetSize;
         else
             sampleFraction = ((double) sampleSize) / inputRdd.cache().count();
         final JavaRDD<Type> outputRdd = inputRdd.sample(false, sampleFraction);

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBroadcastOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBroadcastOperator.java
@@ -1,6 +1,7 @@
 package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.broadcast.Broadcast;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,7 +11,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.BroadcastChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Collection;
@@ -32,7 +32,10 @@ public class SparkBroadcastOperator<Type> extends UnaryToUnaryOperator<Type, Typ
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCacheOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCacheOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.spark.operators;
 import org.apache.commons.lang3.Validate;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimator;
 import org.qcri.rheem.core.optimizer.cardinality.DefaultCardinalityEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
@@ -12,7 +13,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Collections;
@@ -31,7 +31,10 @@ public class SparkCacheOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         RddChannel.Instance input = (RddChannel.Instance) inputs[0];
         final JavaRDD<Object> rdd = input.provideRdd();
         final JavaRDD<Object> cachedRdd = rdd.cache();

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCartesianOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCartesianOperator.java
@@ -4,6 +4,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.CartesianOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -11,7 +12,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -44,7 +44,10 @@ public class SparkCartesianOperator<InputType0, InputType1>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCollectOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCollectOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.commons.lang3.Validate;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimator;
 import org.qcri.rheem.core.optimizer.cardinality.DefaultCardinalityEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
@@ -10,10 +11,9 @@ import org.qcri.rheem.core.plan.rheemplan.UnaryToUnaryOperator;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.channels.CollectionChannel;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -33,7 +33,10 @@ public class SparkCollectOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         RddChannel.Instance input = (RddChannel.Instance) inputs[0];
         CollectionChannel.Instance output = (CollectionChannel.Instance) outputs[0];
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCollectionSource.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCollectionSource.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.CollectionSource;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,10 +11,9 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.RheemCollections;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.channels.CollectionChannel;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.*;
@@ -48,7 +48,10 @@ public class SparkCollectionSource<Type> extends CollectionSource<Type> implemen
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length <= 1;
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCountOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkCountOperator.java
@@ -1,6 +1,7 @@
 package org.qcri.rheem.spark.operators;
 
 import org.qcri.rheem.basic.operators.CountOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,7 +10,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -45,7 +45,10 @@ public class SparkCountOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkDistinctOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkDistinctOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.DistinctOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,7 +10,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -45,7 +45,10 @@ public class SparkDistinctOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkDoWhileOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkDoWhileOperator.java
@@ -5,6 +5,7 @@ import org.qcri.rheem.basic.operators.DoWhileOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.function.PredicateDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,7 +14,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.*;
@@ -52,14 +52,16 @@ public class SparkDoWhileOperator<InputType, ConvergenceType>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler,
-                         SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
         final RddChannel.Instance iterationInput;
         final Function<Collection<ConvergenceType>, Boolean> stoppingCondition =
-                compiler.compile(this.criterionDescriptor, this, inputs);
+                sparkExecutor.getCompiler().compile(this.criterionDescriptor, this, operatorContext, inputs);
         boolean endloop = false;
         switch (this.getState()) {
             case NOT_STARTED:

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkExecutionOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkExecutionOperator.java
@@ -2,9 +2,9 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.ChannelInstance;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 
@@ -23,12 +23,15 @@ public interface SparkExecutionOperator extends ExecutionOperator {
      * a set of {@link ChannelInstance}s according to the operator outputs -- unless the operator is a sink, then it triggers
      * execution.
      *
-     * @param inputs        {@link ChannelInstance}s that satisfy the inputs of this operator
-     * @param outputs       {@link ChannelInstance}s that accept the outputs of this operator
-     * @param compiler      compiles functions used by the operator
-     * @param sparkExecutor {@link SparkExecutor} that executes this instance
+     * @param inputs          {@link ChannelInstance}s that satisfy the inputs of this operator
+     * @param outputs         {@link ChannelInstance}s that accept the outputs of this operator
+     * @param sparkExecutor   {@link SparkExecutor} that executes this instance
+     * @param operatorContext optimization information for this instance
      */
-    void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor);
+    void evaluate(ChannelInstance[] inputs,
+                  ChannelInstance[] outputs,
+                  SparkExecutor sparkExecutor,
+                  OptimizationContext.OperatorContext operatorContext);
 
     /**
      * Utility method to name an RDD according to this instance's name.

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.GlobalMaterializedGroupOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,7 +11,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.BroadcastChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.*;
@@ -41,7 +41,10 @@ public class SparkGlobalMaterializedGroupOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkIntersectOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkIntersectOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.spark.operators;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.IntersectOperator;
 import org.qcri.rheem.basic.operators.JoinOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,7 +11,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -41,7 +41,10 @@ public class SparkIntersectOperator<Type> extends IntersectOperator<Type> implem
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkJoinOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkJoinOperator.java
@@ -7,6 +7,7 @@ import org.apache.spark.api.java.function.PairFunction;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.JoinOperator;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -50,7 +51,10 @@ public class SparkJoinOperator<InputType0, InputType1, KeyType>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
@@ -61,6 +65,7 @@ public class SparkJoinOperator<InputType0, InputType1, KeyType>
         final JavaRDD<InputType0> inputRdd0 = input0.provideRdd();
         final JavaRDD<InputType1> inputRdd1 = input1.provideRdd();
 
+        FunctionCompiler compiler = sparkExecutor.getCompiler();
         final PairFunction<InputType0, KeyType, InputType0> keyExtractor0 = compiler.compileToKeyExtractor(this.keyDescriptor0);
         final PairFunction<InputType1, KeyType, InputType1> keyExtractor1 = compiler.compileToKeyExtractor(this.keyDescriptor1);
         JavaPairRDD<KeyType, InputType0> pairStream0 = inputRdd0.mapToPair(keyExtractor0);

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkLocalCallbackSink.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkLocalCallbackSink.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.LocalCallbackSink;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,7 +10,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -41,7 +41,10 @@ public class SparkLocalCallbackSink<T> extends LocalCallbackSink<T> implements S
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkLoopOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkLoopOperator.java
@@ -5,6 +5,7 @@ import org.qcri.rheem.basic.operators.LoopOperator;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.function.PredicateDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,7 +14,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.*;
@@ -54,8 +54,10 @@ public class SparkLoopOperator<InputType, ConvergenceType>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler,
-                         SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
@@ -63,7 +65,7 @@ public class SparkLoopOperator<InputType, ConvergenceType>
         final CollectionChannel.Instance convergenceInput;
 
         final Function<Collection<ConvergenceType>, Boolean> stoppingCondition =
-                compiler.compile(this.criterionDescriptor, this, inputs);
+                sparkExecutor.getCompiler().compile(this.criterionDescriptor, this, operatorContext, inputs);
         boolean endloop = false;
 
         switch (this.getState()) {
@@ -162,7 +164,7 @@ public class SparkLoopOperator<InputType, ConvergenceType>
                 throw new IllegalStateException(String.format("%s has no %d-th input.", this, index));
         }
     }
-    
+
     @Override
     public boolean isExecutedEagerly() {
         return true;

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkMapPartitionsOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkMapPartitionsOperator.java
@@ -4,6 +4,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.qcri.rheem.basic.operators.MapOperator;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +13,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.BroadcastChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.*;
@@ -27,7 +27,6 @@ public class SparkMapPartitionsOperator<InputType, OutputType>
 
     /**
      * Creates a new instance.
-     *
      */
     public SparkMapPartitionsOperator(TransformationDescriptor<InputType, OutputType> functionDescriptor,
                                       DataSetType<InputType> inputType, DataSetType<OutputType> outputType) {
@@ -36,7 +35,6 @@ public class SparkMapPartitionsOperator<InputType, OutputType>
 
     /**
      * Creates a new instance.
-     *
      */
     public SparkMapPartitionsOperator(TransformationDescriptor<InputType, OutputType> functionDescriptor) {
         this(functionDescriptor,
@@ -54,7 +52,10 @@ public class SparkMapPartitionsOperator<InputType, OutputType>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
@@ -62,7 +63,7 @@ public class SparkMapPartitionsOperator<InputType, OutputType>
         final RddChannel.Instance output = (RddChannel.Instance) outputs[0];
 
         final FlatMapFunction<Iterator<InputType>, OutputType> mapFunction =
-                compiler.compileForMapPartitions(this.functionDescriptor, this, inputs);
+                sparkExecutor.getCompiler().compileForMapPartitions(this.functionDescriptor, this, operatorContext, inputs);
 
         final JavaRDD<InputType> inputRdd = input.provideRdd();
         final JavaRDD<OutputType> outputRdd = inputRdd.mapPartitions(mapFunction);

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkObjectFileSink.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkObjectFileSink.java
@@ -1,6 +1,7 @@
 package org.qcri.rheem.spark.operators;
 
 import org.qcri.rheem.basic.channels.FileChannel;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,7 +11,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,10 @@ public class SparkObjectFileSink<T> extends UnarySink<T> implements SparkExecuti
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length <= 1;
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkObjectFileSource.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkObjectFileSource.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.channels.FileChannel;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +13,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 import org.slf4j.Logger;
@@ -43,7 +43,10 @@ public class SparkObjectFileSource<T> extends UnarySource<T> implements SparkExe
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         final String sourcePath;
         if (this.sourcePath != null) {
             assert inputs.length == 0;

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
@@ -4,13 +4,13 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.SampleOperator;
 import org.qcri.rheem.core.api.exception.RheemException;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +70,10 @@ public class SparkRandomPartitionSampleOperator<Type>
     int threshold = 5000;
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRepeatOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRepeatOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.qcri.rheem.basic.operators.RepeatOperator;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,7 +10,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -40,8 +40,10 @@ public class SparkRepeatOperator<Type>
 
     @Override
     @SuppressWarnings("unchecked")
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler,
-                         SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
@@ -4,6 +4,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function2;
 import org.qcri.rheem.basic.operators.SampleOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.DefaultLoadEstimator;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
@@ -13,7 +14,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import scala.collection.JavaConversions;
 import scala.collection.convert.Wrappers;
@@ -65,7 +65,10 @@ public class SparkShufflePartitionSampleOperator<Type>
     int nb_partitions = 0;
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkSortOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkSortOperator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.spark.operators;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.SortOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -10,7 +11,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import scala.Tuple2;
 
@@ -46,7 +46,10 @@ public class SparkSortOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTextFileSink.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTextFileSink.java
@@ -4,10 +4,10 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.qcri.rheem.basic.operators.TextFileSink;
 import org.qcri.rheem.core.function.TransformationDescriptor;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -28,11 +28,15 @@ public class SparkTextFileSink<T> extends TextFileSink<T> implements SparkExecut
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == 1;
         assert outputs.length == 0;
         JavaRDD<T> inputRdd = ((RddChannel.Instance) inputs[0]).provideRdd();
-        final Function<T, String> formattingFunction = compiler.compile(this.formattingDescriptor, this, inputs);
+        final Function<T, String> formattingFunction =
+                sparkExecutor.getCompiler().compile(this.formattingDescriptor, this, operatorContext, inputs);
         inputRdd.map(formattingFunction).saveAsTextFile(this.textFileUrl);
     }
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTextFileSource.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTextFileSource.java
@@ -2,13 +2,13 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.TextFileSource;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Collection;
@@ -39,7 +39,10 @@ public class SparkTextFileSource extends TextFileSource implements SparkExecutio
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTsvFileSink.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTsvFileSink.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.spark.operators;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -12,7 +13,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 
@@ -43,11 +43,14 @@ public class SparkTsvFileSink<T extends Tuple2<?, ?>> extends UnarySink<T> imple
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor executor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
 
         final FileChannel.Instance output = (FileChannel.Instance) outputs[0];
-        final String targetPath = output.addGivenOrTempPath(this.targetPath, executor.getConfiguration());
+        final String targetPath = output.addGivenOrTempPath(this.targetPath, sparkExecutor.getConfiguration());
 
         final RddChannel.Instance input = (RddChannel.Instance) inputs[0];
         final JavaRDD<Object> rdd = input.provideRdd();

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTsvFileSource.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkTsvFileSource.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.spark.operators;
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.basic.data.Tuple2;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,7 +14,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.fs.FileSystems;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 
@@ -40,7 +40,10 @@ public class SparkTsvFileSource<T> extends UnarySource<T> implements SparkExecut
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         final String sourcePath;
         if (this.sourcePath != null) {
             assert inputs.length == 0;

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkUnionAllOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkUnionAllOperator.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark.operators;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.operators.UnionAllOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -9,7 +10,6 @@ import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -41,7 +41,10 @@ public class SparkUnionAllOperator<Type>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkZipWithIdOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkZipWithIdOperator.java
@@ -5,6 +5,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.basic.operators.MapOperator;
 import org.qcri.rheem.basic.operators.ZipWithIdOperator;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileEstimator;
 import org.qcri.rheem.core.optimizer.costs.NestableLoadProfileEstimator;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -13,7 +14,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.BroadcastChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.util.Arrays;
@@ -53,7 +53,10 @@ public class SparkZipWithIdOperator<InputType>
     }
 
     @Override
-    public void evaluate(ChannelInstance[] inputs, ChannelInstance[] outputs, FunctionCompiler compiler, SparkExecutor sparkExecutor) {
+    public void evaluate(ChannelInstance[] inputs,
+                         ChannelInstance[] outputs,
+                         SparkExecutor sparkExecutor,
+                         OptimizationContext.OperatorContext operatorContext) {
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 

--- a/rheem-platforms/rheem-spark/src/main/scala/org/qcri/rheem/spark/operators/graph/SparkPageRankOperator.scala
+++ b/rheem-platforms/rheem-spark/src/main/scala/org/qcri/rheem/spark/operators/graph/SparkPageRankOperator.scala
@@ -1,23 +1,21 @@
 package org.qcri.rheem.spark.operators.graph
 
-import java.util
-
-import org.qcri.rheem.basic.operators.PageRankOperator
-import org.qcri.rheem.core.platform.{ChannelDescriptor, ChannelInstance}
-import org.qcri.rheem.spark.channels.RddChannel
-import org.qcri.rheem.spark.compiler.FunctionCompiler
-import org.qcri.rheem.spark.execution.SparkExecutor
-import org.qcri.rheem.spark.operators.SparkExecutionOperator
-import org.qcri.rheem.basic.data.{Tuple2 => T2}
 import java.lang.{Long => JavaLong}
+import java.util
 import java.util.Collections
 
 import org.apache.spark.graphx.Graph
 import org.apache.spark.graphx.lib.PageRank
-import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval
+import org.qcri.rheem.basic.data.{Tuple2 => T2}
+import org.qcri.rheem.basic.operators.PageRankOperator
+import org.qcri.rheem.core.optimizer.{OptimizationContext, ProbabilisticDoubleInterval}
+import org.qcri.rheem.core.platform.{ChannelDescriptor, ChannelInstance}
+import org.qcri.rheem.spark.channels.RddChannel
+import org.qcri.rheem.spark.execution.SparkExecutor
+import org.qcri.rheem.spark.operators.SparkExecutionOperator
 
 /**
-  *
+  * GraphX-based implementation of the [[PageRankOperator]].
   */
 class SparkPageRankOperator(_numIterations: Int,
                             _dampingFactor: Float,
@@ -26,7 +24,10 @@ class SparkPageRankOperator(_numIterations: Int,
 
   def this(that: PageRankOperator) = this(that.getNumIterations, that.getDampingFactor, that.getGraphDensity)
 
-  override def evaluate(inputs: Array[ChannelInstance], outputs: Array[ChannelInstance], compiler: FunctionCompiler, sparkExecutor: SparkExecutor): Unit = {
+  override def evaluate(inputs: Array[ChannelInstance],
+                        outputs: Array[ChannelInstance],
+                        sparkExecutor: SparkExecutor,
+                        operatorContext: OptimizationContext#OperatorContext): Unit = {
     val input = inputs(0).asInstanceOf[RddChannel#Instance]
     val output = outputs(0).asInstanceOf[RddChannel#Instance]
 
@@ -35,7 +36,7 @@ class SparkPageRankOperator(_numIterations: Int,
     val graph = Graph.fromEdgeTuples(edgeRdd, null)
     val prGraph = PageRank.run(graph, this.numIterations, 1d - this.dampingFactor)
     val resultRdd = prGraph.vertices
-      .map { case (vertexId, pageRank) => new T2(vertexId, pageRank.toFloat)}
+      .map { case (vertexId, pageRank) => new T2(vertexId, pageRank.toFloat) }
       .toJavaRDD
 
     output.accept(resultRdd, sparkExecutor)

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperatorTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +30,7 @@ public class SparkBernoulliSampleOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{this.createRddChannelInstance()};
 
         // Execute.
-        sampleOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(sampleOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = ((RddChannel.Instance) outputs[0]).<Integer>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCartesianOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCartesianOperatorTest.java
@@ -6,7 +6,6 @@ import org.qcri.rheem.basic.data.Tuple2;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class SparkCartesianOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        cartesianOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(cartesianOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Tuple2<Integer, String>> result = output.<Tuple2<Integer, String>>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCollectionSourceTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCollectionSourceTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -29,7 +28,7 @@ public class SparkCollectionSourceTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        collectionSource.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(collectionSource, inputs, outputs);
 
         final Set<Integer> outputValues = new HashSet<>(output.<Integer>provideRdd().collect());
         Assert.assertEquals(outputValues, inputValues);

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCountOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkCountOperatorTest.java
@@ -6,11 +6,9 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 
 /**
@@ -33,7 +31,7 @@ public class SparkCountOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        countOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(countOperator, inputs, outputs);
 
         // Verify the outcome.
         final Collection<Integer> result = output.provideCollection();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkDistinctOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkDistinctOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +30,7 @@ public class SparkDistinctOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{this.createRddChannelInstance()};
 
         // Execute.
-        distinctOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(distinctOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = ((RddChannel.Instance) outputs[0]).<Integer>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkFilterOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkFilterOperatorTest.java
@@ -6,7 +6,6 @@ import org.qcri.rheem.core.function.PredicateDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class SparkFilterOperatorTest extends SparkOperatorTestBase {
         ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        filterOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(filterOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = output.<Integer>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkFlatMapOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkFlatMapOperatorTest.java
@@ -6,11 +6,8 @@ import org.qcri.rheem.core.function.FlatMapDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -35,7 +32,7 @@ public class SparkFlatMapOperatorTest extends SparkOperatorTestBase {
         ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        flatMapOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(flatMapOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<String> result = output.<String>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkGlobalMaterializedGroupOperatorTest.java
@@ -6,7 +6,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.RheemCollections;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,7 +31,7 @@ public class SparkGlobalMaterializedGroupOperatorTest extends SparkOperatorTestB
         // Execute.
         ChannelInstance[] inputs = new RddChannel.Instance[]{this.createRddChannelInstance(inputCollection)};
         ChannelInstance[] outputs = new RddChannel.Instance[]{this.createRddChannelInstance()};
-        globalGroup.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(globalGroup, inputs, outputs);
 
         // Verify the outcome.
         final Collection<Iterable<Integer>> result = ((RddChannel.Instance) outputs[0]).<Iterable<Integer>>provideRdd().collect();
@@ -56,7 +55,7 @@ public class SparkGlobalMaterializedGroupOperatorTest extends SparkOperatorTestB
         // Execute.
         ChannelInstance[] inputs = new RddChannel.Instance[]{this.createRddChannelInstance(inputCollection)};
         ChannelInstance[] outputs = new RddChannel.Instance[]{this.createRddChannelInstance()};
-        globalGroup.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(globalGroup, inputs, outputs);
 
         // Verify the outcome.
         final Collection<Iterable<Integer>> result = ((RddChannel.Instance) outputs[0]).<Iterable<Integer>>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkGlobalReduceOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkGlobalReduceOperatorTest.java
@@ -11,7 +11,6 @@ import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.core.util.RheemCollections;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,7 +42,7 @@ public class SparkGlobalReduceOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        globalReduce.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(globalReduce, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = RheemCollections.asList(output.provideCollection());
@@ -74,7 +73,7 @@ public class SparkGlobalReduceOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        globalReduce.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(globalReduce, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = RheemCollections.asList(output.provideCollection());

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkJoinOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkJoinOperatorTest.java
@@ -8,7 +8,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +45,7 @@ public class SparkJoinOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        join.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(join, inputs, outputs);
 
         // Verify the outcome.
         final List<Tuple2<Tuple2<Integer, String>, Tuple2<String, Integer>>> result =

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkMapPartitionsOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkMapPartitionsOperatorTest.java
@@ -2,19 +2,11 @@ package org.qcri.rheem.spark.operators;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.qcri.rheem.core.function.FlatMapDescriptor;
-import org.qcri.rheem.core.function.FunctionDescriptor;
-import org.qcri.rheem.core.function.PredicateDescriptor;
 import org.qcri.rheem.core.function.TransformationDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
-import org.qcri.rheem.core.types.DataSetType;
-import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -31,15 +23,15 @@ public class SparkMapPartitionsOperatorTest extends SparkOperatorTestBase {
         // Create the mapPartitions operator.
         SparkMapPartitionsOperator<Integer, Integer> mapPartitionsOperator =
                 new SparkMapPartitionsOperator<>(
-                         new TransformationDescriptor<>(item -> item + 1, Integer.class, Integer.class)
-                        );
+                        new TransformationDescriptor<>(item -> item + 1, Integer.class, Integer.class)
+                );
 
         // Set up the ChannelInstances.
         ChannelInstance[] inputs = new ChannelInstance[]{input};
         ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        mapPartitionsOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(mapPartitionsOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = output.<Integer>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkMaterializedGroupByOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkMaterializedGroupByOperatorTest.java
@@ -8,7 +8,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +47,7 @@ public class SparkMaterializedGroupByOperatorTest extends SparkOperatorTestBase 
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        collocateByOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(collocateByOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Iterable<Tuple2<String, Integer>>> originalResult =

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkObjectFileSinkTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkObjectFileSinkTest.java
@@ -6,7 +6,6 @@ import org.qcri.rheem.basic.channels.FileChannel;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.io.IOException;
@@ -43,7 +42,7 @@ public class SparkObjectFileSinkTest extends SparkOperatorTestBase {
             final ChannelInstance[] outputs = new ChannelInstance[]{outputChannel};
 
             // Execute.
-            sink.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+            this.evaluate(sink, inputs, outputs);
         } finally {
             if (sparkExecutor != null) sparkExecutor.dispose();
         }

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkObjectFileSourceTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkObjectFileSourceTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 
 import java.io.IOException;
@@ -37,7 +36,7 @@ public class SparkObjectFileSourceTest extends SparkOperatorTestBase {
             final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
             // Execute.
-            source.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+            this.evaluate(source, inputs, outputs);
 
             // Verify.
             Set<Integer> expectedValues = new HashSet<>(SparkObjectFileSourceTest.enumerateRange(10000));

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkOperatorTestBase.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkOperatorTestBase.java
@@ -4,6 +4,10 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.Before;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.Job;
+import org.qcri.rheem.core.optimizer.DefaultOptimizationContext;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.plan.rheemplan.Operator;
+import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.platform.CrossPlatformExecutor;
 import org.qcri.rheem.core.profiling.FullInstrumentationStrategy;
 import org.qcri.rheem.java.channels.CollectionChannel;
@@ -37,6 +41,17 @@ public class SparkOperatorTestBase {
         when(job.getConfiguration()).thenReturn(this.configuration);
         when(job.getCrossPlatformExecutor()).thenReturn(new CrossPlatformExecutor(job, new FullInstrumentationStrategy()));
         return job;
+    }
+
+    protected OptimizationContext.OperatorContext createOperatorContext(Operator operator) {
+        OptimizationContext optimizationContext = new DefaultOptimizationContext(this.configuration);
+        return optimizationContext.addOneTimeOperator(operator);
+    }
+
+    protected void evaluate(SparkExecutionOperator operator,
+                            ChannelInstance[] inputs,
+                            ChannelInstance[] outputs) {
+        operator.evaluate(inputs, outputs, this.sparkExecutor, this.createOperatorContext(operator));
     }
 
     RddChannel.Instance createRddChannelInstance() {

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperatorTest.java
@@ -7,7 +7,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.RheemCollections;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,7 +35,7 @@ public class SparkRandomPartitionSampleOperatorTest extends SparkOperatorTestBas
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        sampleOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(sampleOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = RheemCollections.asList(output.provideCollection());

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkReduceByOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkReduceByOperatorTest.java
@@ -9,7 +9,6 @@ import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.types.DataUnitType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -53,7 +52,7 @@ public class SparkReduceByOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        reduceByOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(reduceByOperator, inputs, outputs);
 
         // Verify the outcome.
         final Iterable<Tuple2<String, Integer>> result = output.<Tuple2<String, Integer>>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperatorTest.java
@@ -7,7 +7,6 @@ import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.RheemCollections;
 import org.qcri.rheem.java.channels.CollectionChannel;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +36,7 @@ public class SparkShufflePartitionSampleOperatorTest extends SparkOperatorTestBa
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        sampleOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(sampleOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = RheemCollections.asList(output.provideCollection());

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkSortOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkSortOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +32,7 @@ public class SparkSortOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        sortOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(sortOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = output.<Integer>provideRdd().collect();

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkTextFileSinkTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkTextFileSinkTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.function.TransformationDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,7 +35,7 @@ public class SparkTextFileSinkTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{};
 
         // Execute.
-        sink.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(sink, inputs, outputs);
     }
 
 }

--- a/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkUnionAllOperatorTest.java
+++ b/rheem-platforms/rheem-spark/src/test/java/org/qcri/rheem/spark/operators/SparkUnionAllOperatorTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.spark.channels.RddChannel;
-import org.qcri.rheem.spark.compiler.FunctionCompiler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ public class SparkUnionAllOperatorTest extends SparkOperatorTestBase {
         final ChannelInstance[] outputs = new ChannelInstance[]{output};
 
         // Execute.
-        unionAllOperator.evaluate(inputs, outputs, new FunctionCompiler(), this.sparkExecutor);
+        this.evaluate(unionAllOperator, inputs, outputs);
 
         // Verify the outcome.
         final List<Integer> result = output.<Integer>provideRdd().collect();

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/BinaryOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/BinaryOperatorProfiler.java
@@ -2,7 +2,6 @@ package org.qcri.rheem.profiler.java;
 
 import org.qcri.rheem.core.plan.rheemplan.InputSlot;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 
 import java.util.ArrayList;
@@ -53,10 +52,9 @@ public class BinaryOperatorProfiler extends OperatorProfiler {
 
 
     public long executeOperator() {
-        this.operator.evaluate(
+        this.evaluate(
                 new JavaChannelInstance[]{this.inputChannelInstance0, this.inputChannelInstance1},
-                new JavaChannelInstance[]{this.outputChannelInstance},
-                new FunctionCompiler(null)
+                new JavaChannelInstance[]{this.outputChannelInstance}
         );
         return this.outputChannelInstance.provideStream().count();
     }

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/OperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/OperatorProfiler.java
@@ -1,11 +1,15 @@
 package org.qcri.rheem.profiler.java;
 
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.DefaultOptimizationContext;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.plan.executionplan.Channel;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
+import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.util.RheemArrays;
 import org.qcri.rheem.core.util.RheemCollections;
 import org.qcri.rheem.java.channels.CollectionChannel;
+import org.qcri.rheem.java.execution.JavaExecutor;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 import org.qcri.rheem.profiler.util.ProfilingUtils;
 import org.slf4j.Logger;
@@ -31,6 +35,8 @@ public abstract class OperatorProfiler {
 
     protected JavaExecutionOperator operator;
 
+    protected JavaExecutor executor;
+
     protected final List<Supplier<?>> dataQuantumGenerators;
 
     private List<Long> inputCardinalities;
@@ -39,6 +45,7 @@ public abstract class OperatorProfiler {
                             Supplier<?>... dataQuantumGenerators) {
         this.operatorGenerator = operatorGenerator;
         this.dataQuantumGenerators = Arrays.asList(dataQuantumGenerators);
+        this.executor = ProfilingUtils.fakeJavaExecutor();
         this.cpuMhz = Integer.parseInt(System.getProperty("rheem.java.cpu.mhz", "2700"));
     }
 
@@ -103,6 +110,17 @@ public abstract class OperatorProfiler {
 
     public JavaExecutionOperator getOperator() {
         return this.operator;
+    }
+
+    /**
+     * Utility method to invoke
+     * {@link JavaExecutionOperator#evaluate(ChannelInstance[], ChannelInstance[], JavaExecutor, OptimizationContext.OperatorContext)}.
+     */
+    protected void evaluate(ChannelInstance[] inputs,
+                            ChannelInstance[] outputs) {
+        OptimizationContext optimizationContext = new DefaultOptimizationContext(this.executor.getConfiguration());
+        final OptimizationContext.OperatorContext operatorContext = optimizationContext.addOneTimeOperator(operator);
+        operator.evaluate(inputs, outputs, this.executor, operatorContext);
     }
 
     /**

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/SinkProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/SinkProfiler.java
@@ -2,7 +2,6 @@ package org.qcri.rheem.profiler.java;
 
 import org.apache.commons.lang3.Validate;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 
 import java.util.ArrayList;
@@ -38,10 +37,9 @@ public class SinkProfiler extends OperatorProfiler {
 
     @Override
     protected long executeOperator() {
-        this.operator.evaluate(
+        this.evaluate(
                 new JavaChannelInstance[]{this.inputChannelInstance},
-                new JavaChannelInstance[]{},
-                new FunctionCompiler(null)
+                new JavaChannelInstance[]{}
         );
         return 0L;
     }

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/SourceProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/SourceProfiler.java
@@ -2,7 +2,6 @@ package org.qcri.rheem.profiler.java;
 
 import org.apache.commons.lang3.Validate;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +40,9 @@ public abstract class SourceProfiler extends OperatorProfiler {
 
     @Override
     protected long executeOperator() {
-        this.operator.evaluate(
+        this.evaluate(
                 new JavaChannelInstance[]{},
-                new JavaChannelInstance[]{this.outputChannelInstance},
-                new FunctionCompiler(null)
+                new JavaChannelInstance[]{this.outputChannelInstance}
         );
         return this.outputChannelInstance.provideStream().count();
     }

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/UnaryOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/java/UnaryOperatorProfiler.java
@@ -3,7 +3,6 @@ package org.qcri.rheem.profiler.java;
 import org.apache.commons.lang3.Validate;
 import org.qcri.rheem.core.plan.rheemplan.InputSlot;
 import org.qcri.rheem.java.channels.JavaChannelInstance;
-import org.qcri.rheem.java.compiler.FunctionCompiler;
 import org.qcri.rheem.java.operators.JavaExecutionOperator;
 
 import java.util.ArrayList;
@@ -41,10 +40,9 @@ public class UnaryOperatorProfiler extends OperatorProfiler {
 
 
     public long executeOperator() {
-        this.operator.evaluate(
+        this.evaluate(
                 new JavaChannelInstance[]{this.inputChannelInstance},
-                new JavaChannelInstance[]{this.outputChannelInstance},
-                new FunctionCompiler(null)
+                new JavaChannelInstance[]{this.outputChannelInstance}
         );
         return this.outputChannelInstance.provideStream().count();
     }

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/BinaryOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/BinaryOperatorProfiler.java
@@ -46,11 +46,10 @@ public class BinaryOperatorProfiler extends SparkOperatorProfiler {
         // Let the operator execute.
         ProfilingUtils.sleep(this.executionPaddingTime); // Pad measurement with some idle time.
         final long startTime = System.currentTimeMillis();
-        this.operator.evaluate(
+        this.evaluate(
+                this.operator,
                 new ChannelInstance[]{inputChannelInstance0, inputChannelInstance1},
-                new ChannelInstance[]{outputChannelInstance},
-                this.functionCompiler,
-                this.sparkExecutor
+                new ChannelInstance[]{outputChannelInstance}
         );
 
         // Force the execution of the operator.

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SinkProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SinkProfiler.java
@@ -34,11 +34,10 @@ public class SinkProfiler extends SparkOperatorProfiler {
         // Let the operator execute.
         ProfilingUtils.sleep(this.executionPaddingTime); // Pad measurement with some idle time.
         final long startTime = System.currentTimeMillis();
-        this.operator.evaluate(
+        this.evaluate(
+                this.operator,
                 new ChannelInstance[]{inputChannelInstance},
-                new ChannelInstance[]{},
-                this.functionCompiler,
-                this.sparkExecutor
+                new ChannelInstance[]{}
         );
 
         // Complete the measurement.

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkOperatorProfiler.java
@@ -2,6 +2,8 @@ package org.qcri.rheem.profiler.spark;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.DefaultOptimizationContext;
+import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.ChannelInstance;
 import org.qcri.rheem.core.util.ReflectionUtils;
@@ -11,8 +13,8 @@ import org.qcri.rheem.profiler.util.ProfilingUtils;
 import org.qcri.rheem.profiler.util.RrdAccessor;
 import org.qcri.rheem.spark.channels.RddChannel;
 import org.qcri.rheem.spark.compiler.FunctionCompiler;
-import org.qcri.rheem.spark.operators.SparkExecutionOperator;
 import org.qcri.rheem.spark.execution.SparkExecutor;
+import org.qcri.rheem.spark.operators.SparkExecutionOperator;
 import org.rrd4j.ConsolFun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -268,6 +270,18 @@ public abstract class SparkOperatorProfiler {
      * Executes the profiling task. Requires that this instance is prepared.
      */
     protected abstract Result executeOperator();
+
+    /**
+     * Utility method to invoke
+     * {@link SparkExecutionOperator#evaluate(ChannelInstance[], ChannelInstance[], SparkExecutor, OptimizationContext.OperatorContext)}.
+     */
+    protected void evaluate(SparkExecutionOperator operator,
+                           ChannelInstance[] inputs,
+                           ChannelInstance[] outputs) {
+        OptimizationContext optimizationContext = new DefaultOptimizationContext(this.sparkExecutor.getConfiguration());
+        final OptimizationContext.OperatorContext operatorContext = optimizationContext.addOneTimeOperator(operator);
+        operator.evaluate(inputs, outputs, this.sparkExecutor, operatorContext);
+    }
 
     /**
      * Creates a {@link ChannelInstance} that carries the given {@code rdd}.

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkSourceProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkSourceProfiler.java
@@ -26,11 +26,10 @@ public abstract class SparkSourceProfiler extends SparkOperatorProfiler {
         // Let the operator execute.
         ProfilingUtils.sleep(this.executionPaddingTime); // Pad measurement with some idle time.
         final long startTime = System.currentTimeMillis();
-        this.operator.evaluate(
+        this.evaluate(
+                this.operator,
                 new ChannelInstance[]{},
-                new ChannelInstance[]{outputChannelInstance},
-                this.functionCompiler,
-                this.sparkExecutor
+                new ChannelInstance[]{outputChannelInstance}
         );
 
         // Force the execution of the operator.

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkUnaryOperatorProfiler.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/spark/SparkUnaryOperatorProfiler.java
@@ -36,11 +36,10 @@ public class SparkUnaryOperatorProfiler extends SparkOperatorProfiler {
         // Let the operator execute.
         ProfilingUtils.sleep(this.executionPaddingTime); // Pad measurement with some idle time.
         final long startTime = System.currentTimeMillis();
-        this.operator.evaluate(
+        this.evaluate(
+                this.operator,
                 new ChannelInstance[]{inputChannelInstance},
-                new ChannelInstance[]{outputChannelInstance},
-                this.functionCompiler,
-                this.sparkExecutor
+                new ChannelInstance[]{outputChannelInstance}
         );
 
         // Force the execution of the operator.

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/util/ProfilingUtils.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/util/ProfilingUtils.java
@@ -5,6 +5,8 @@ import org.qcri.rheem.core.api.RheemContext;
 import org.qcri.rheem.core.plan.rheemplan.RheemPlan;
 import org.qcri.rheem.core.util.Formats;
 import org.qcri.rheem.core.util.ReflectionUtils;
+import org.qcri.rheem.java.execution.JavaExecutor;
+import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.spark.execution.SparkExecutor;
 import org.qcri.rheem.spark.platform.SparkPlatform;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,13 @@ public class ProfilingUtils {
      */
     public static SparkExecutor fakeSparkExecutor(String... udfJars) {
         return (SparkExecutor) SparkPlatform.getInstance().createExecutor(fakeJob(udfJars));
+    }
+
+    /**
+     * Provides a {@link JavaExecutor}.
+     */
+    public static JavaExecutor fakeJavaExecutor() {
+        return (JavaExecutor) JavaPlatform.getInstance().createExecutor(fakeJob());
     }
 
     /**

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/FullIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/FullIntegrationIT.java
@@ -400,6 +400,17 @@ public class FullIntegrationIT {
     }
 
     @Test
+    public void testCurrentIterationNumber() {
+        RheemContext rheemContext = new RheemContext().with(Java.basicPlugin()).with(Spark.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        int expectedOffset = 10;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
+    @Test
     public void testGroupByOperator() {
         final CollectionSource<String> source = new CollectionSource<>(
                 Arrays.asList("a", "b", "a", "ab", "aa", "bb"),

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/JavaIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/JavaIntegrationIT.java
@@ -358,6 +358,17 @@ public class JavaIntegrationIT {
     }
 
     @Test
+    public void testCurrentIterationNumber() {
+        RheemContext rheemContext = new RheemContext().with(Java.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        int expectedOffset = 5 * 4 / 2;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
+    @Test
     public void testBroadcasts() {
         Collection<Integer> broadcastedValues = Arrays.asList(1, 2, 3, 4);
         Collection<Integer> mainValues = Arrays.asList(2, 4, 6, 2);

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
@@ -354,6 +354,17 @@ public class SparkIntegrationIT {
     }
 
     @Test
+    public void testCurrentIterationNumber() {
+        RheemContext rheemContext = new RheemContext().with(Spark.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        int expectedOffset = 10;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
+    @Test
     public void testBroadcasts() {
         Collection<Integer> broadcastedValues = Arrays.asList(1, 2, 3, 4);
         Collection<Integer> mainValues = Arrays.asList(2, 4, 6, 2);


### PR DESCRIPTION
This PR extends the `evaluate` methods of `JavaExecutionOperator`s and `SparkExecutionOperator`s with the `OperatorContext` of that respective operator. Futhermore, the `ExecutionContext` provides the current iteration number to extended UDFs that have a `open(...)` method.

This closes #17.