### PR TITLE
Dynamically add OptimizationContexts for unexpected iterations.

### DIFF
--- a/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuantaBuilder.scala
+++ b/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuantaBuilder.scala
@@ -1339,7 +1339,7 @@ class DoWhileDataQuantaBuilder[T, ConvOut](inputDataQuanta: DataQuantaBuilder[_,
     * @param numExpectedIterations the expected number of iterations
     * @return this instance
     */
-  def withExpectedNumberOfiterations(numExpectedIterations: Int) = {
+  def withExpectedNumberOfIterations(numExpectedIterations: Int) = {
     this.numExpectedIterations = numExpectedIterations
     this
   }

--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/data/Record.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/data/Record.java
@@ -94,4 +94,13 @@ public class Record implements Serializable {
         return field == null ? null : field.toString();
     }
 
+    /**
+     * Retrieve the size of this instance.
+     *
+     * @return the number of fields in this instance
+     */
+    public int size() {
+        return this.values.length;
+    }
+
 }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/DefaultOptimizationContext.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/DefaultOptimizationContext.java
@@ -1,6 +1,8 @@
 package org.qcri.rheem.core.optimizer;
 
 import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.channels.ChannelConversionGraph;
+import org.qcri.rheem.core.optimizer.enumeration.PlanEnumerationPruningStrategy;
 import org.qcri.rheem.core.plan.rheemplan.*;
 import org.qcri.rheem.core.util.RheemArrays;
 
@@ -75,6 +77,23 @@ public class DefaultOptimizationContext extends OptimizationContext {
                 hostLoopContext.getOptimizationContext().getChannelConversionGraph(),
                 hostLoopContext.getOptimizationContext().getPruningStrategies());
         this.addOneTimeOperators(loop);
+    }
+
+    /**
+     * Base constructor.
+     */
+    private DefaultOptimizationContext(Configuration configuration,
+                                       OptimizationContext base,
+                                       LoopContext hostLoopContext,
+                                       int iterationNumber,
+                                       ChannelConversionGraph channelConversionGraph,
+                                       List<PlanEnumerationPruningStrategy> pruningStrategies,
+                                       Map<Operator, OperatorContext> operatorContexts,
+                                       Map<LoopSubplan, LoopContext> loopContexts) {
+        super(configuration, base, hostLoopContext, iterationNumber, channelConversionGraph, pruningStrategies);
+        this.operatorContexts.putAll(operatorContexts);
+        this.loopContexts.putAll(loopContexts);
+
     }
 
     @Override
@@ -187,5 +206,23 @@ public class DefaultOptimizationContext extends OptimizationContext {
     @Override
     public Collection<DefaultOptimizationContext> getDefaultOptimizationContexts() {
         return Collections.singleton(this);
+    }
+
+    /**
+     * Create a shallow copy of this instance.
+     *
+     * @return the shallow copy
+     */
+    public DefaultOptimizationContext copy() {
+        return new DefaultOptimizationContext(
+                this.getConfiguration(),
+                this.getBase(),
+                this.getLoopContext(),
+                this.getIterationNumber(),
+                this.getChannelConversionGraph(),
+                this.getPruningStrategies(),
+                this.operatorContexts,
+                this.loopContexts
+        );
     }
 }

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/FullIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/FullIntegrationIT.java
@@ -402,7 +402,18 @@ public class FullIntegrationIT {
     @Test
     public void testCurrentIterationNumber() {
         RheemContext rheemContext = new RheemContext().with(Java.basicPlugin()).with(Spark.basicPlugin());
-        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 5, -1, 1, 5);
+        int expectedOffset = 10;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
+    @Test
+    public void testCurrentIterationNumberWithTooFewExpectedIterations() {
+        RheemContext rheemContext = new RheemContext().with(Java.basicPlugin()).with(Spark.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 2, -1, 1, 5);
         int expectedOffset = 10;
         Assert.assertEquals(
                 RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/JavaIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/JavaIntegrationIT.java
@@ -360,13 +360,25 @@ public class JavaIntegrationIT {
     @Test
     public void testCurrentIterationNumber() {
         RheemContext rheemContext = new RheemContext().with(Java.basicPlugin());
-        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 5, -1, 1, 5);
         int expectedOffset = 5 * 4 / 2;
         Assert.assertEquals(
                 RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
                 RheemCollections.asSet(result)
         );
     }
+
+    @Test
+    public void testCurrentIterationNumberWithTooFewExpectedIterations() {
+        RheemContext rheemContext = new RheemContext().with(Java.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 2, -1, 1, 5);
+        int expectedOffset = 5 * 4 / 2;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
 
     @Test
     public void testBroadcasts() {

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/RheemPlans.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/RheemPlans.java
@@ -266,6 +266,7 @@ public class RheemPlans {
      */
     public static Collection<Integer> loopWithIterationNumber(RheemContext rheemContext,
                                                               final int maxValue,
+                                                              final int expectedNumIterations,
                                                               final int... values) {
         return new JavaPlanBuilder(rheemContext)
                 .loadCollection(RheemArrays.asList(values)).withName("Load values")
@@ -285,7 +286,7 @@ public class RheemPlans {
                                     newVals.map(x -> x).withName("Identity 2").withOutputClass(Integer.class)
                             );
                         }
-                ).withConditionClass(Integer.class)
+                ).withExpectedNumberOfIterations(expectedNumIterations).withConditionClass(Integer.class)
                 .collect();
     }
 

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
@@ -367,7 +367,7 @@ public class SparkIntegrationIT {
     @Test
     public void testCurrentIterationNumberWithTooFewExpectedIterations() {
         RheemContext rheemContext = new RheemContext().with(Spark.basicPlugin());
-        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 2 -1, 1, 5);
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 2, -1, 1, 5);
         int expectedOffset = 10;
         Assert.assertEquals(
                 RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/SparkIntegrationIT.java
@@ -356,7 +356,18 @@ public class SparkIntegrationIT {
     @Test
     public void testCurrentIterationNumber() {
         RheemContext rheemContext = new RheemContext().with(Spark.basicPlugin());
-        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, -1, 1, 5);
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 5, -1, 1, 5);
+        int expectedOffset = 10;
+        Assert.assertEquals(
+                RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),
+                RheemCollections.asSet(result)
+        );
+    }
+
+    @Test
+    public void testCurrentIterationNumberWithTooFewExpectedIterations() {
+        RheemContext rheemContext = new RheemContext().with(Spark.basicPlugin());
+        final Collection<Integer> result = RheemPlans.loopWithIterationNumber(rheemContext, 15, 2 -1, 1, 5);
         int expectedOffset = 10;
         Assert.assertEquals(
                 RheemCollections.asSet(-1 + expectedOffset, 1 + expectedOffset, 5 + expectedOffset),


### PR DESCRIPTION
As explained in #19, we might need to add new OptimizationContexts during the execution of loops whenever there are more actual iterations than expected. This PR introduces this feature.