### PR TITLE
Add sample methods to the Scala and Java API.

### DIFF
--- a/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuanta.scala
+++ b/rheem-api/src/main/scala/org/qcri/rheem/api/DataQuanta.scala
@@ -172,6 +172,28 @@ class DataQuanta[Out: ClassTag](val operator: ElementaryOperator, outputIndex: I
   }
 
   /**
+    * Feed this instance into a [[SampleOperator]].
+    *
+    * @param sampleSize   absolute size of the sample
+    * @param datasetSize  optional size of the dataset to be sampled
+    * @param sampleMethod the [[SampleOperator.Methods]] to use for sampling
+    * @return a new instance representing the [[FlatMapOperator]]'s output
+    */
+  def sample(sampleSize: Int,
+             datasetSize: Long = SampleOperator.UNKNOWN_DATASET_SIZE,
+             sampleMethod: SampleOperator.Methods = SampleOperator.Methods.ANY): DataQuanta[Out] = {
+    val sampleOperator = new SampleOperator(
+      sampleSize,
+      datasetSize,
+      dataSetType[Out],
+      sampleMethod
+    )
+    this.connectTo(sampleOperator, 0)
+    sampleOperator
+  }
+
+
+  /**
     * Feed this instance into a [[ReduceByOperator]].
     *
     * @param keyUdf     UDF to extract the grouping key from the data quanta

--- a/rheem-api/src/test/java/org/qcri/rheem/api/JavaApiTest.java
+++ b/rheem-api/src/test/java/org/qcri/rheem/api/JavaApiTest.java
@@ -185,6 +185,26 @@ public class JavaApiTest {
     }
 
     @Test
+    public void testSample() {
+        // Set up RheemContext.
+        RheemContext rheemContext = new RheemContext().with(Java.basicPlugin()).with(Spark.basicPlugin());
+
+        // Create some input values.
+        final List<Integer> inputValues = RheemArrays.asList(RheemArrays.range(100));
+
+        // Build and execute a Rheem plan.
+        final Collection<Integer> outputValues = new JavaPlanBuilder(rheemContext)
+                .loadCollection(inputValues).withName("Load input values")
+                .sample(10).withName("Sample")
+                .collect();
+
+        // Check the outcome.
+        Assert.assertEquals(10, outputValues.size());
+        Assert.assertEquals(10, RheemCollections.asSet(outputValues).size());
+
+    }
+
+    @Test
     public void testDoWhile() {
         // Set up RheemContext.
         RheemContext rheemContext = new RheemContext().with(Java.basicPlugin());

--- a/rheem-api/src/test/scala/org/qcri/rheem/api/ApiTest.scala
+++ b/rheem-api/src/test/scala/org/qcri/rheem/api/ApiTest.scala
@@ -143,6 +143,25 @@ class ApiTest {
   }
 
   @Test
+  def testSample(): Unit = {
+    // Set up RheemContext.
+    val rheem = new RheemContext().withPlugin(Java.basicPlugin).withPlugin(Spark.basicPlugin)
+
+    // Generate some test data.
+    val inputValues = for (i <- 0 until 100) yield i
+
+    // Build and execute the RheemPlan.
+    val sample = rheem
+      .loadCollection(inputValues)
+      .sample(10)
+      .collect()
+
+    // Check the result.
+    Assert.assertEquals(10, sample.size)
+    Assert.assertEquals(10, sample.toSet.size)
+  }
+
+  @Test
   def testDoWhile(): Unit = {
     // Set up RheemContext.
     val rheem = new RheemContext().withPlugin(Java.basicPlugin).withPlugin(Spark.basicPlugin)

--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
@@ -100,6 +100,15 @@ public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
         return this.datasetSize;
     }
 
+    /**
+     * Find out whether this instance knows about the size of the incoming dataset.
+     *
+     * @return whether it knows the dataset size
+     */
+    protected boolean isDataSetSizeKnown() {
+        return this.datasetSize > 0;
+    }
+
     public Methods getSampleMethod() {
         return this.sampleMethod;
     }

--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
@@ -37,12 +37,17 @@ public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
         RESERVOIR
     }
 
+    /**
+     * Special dataset size that represents "unknown".
+     */
+    // TODO: With 0 being a legal dataset size, it would be nice to use a different "null" value, e.g., -1.
+    public static final long UNKNOWN_DATASET_SIZE = 0L;
+
     protected int sampleSize;
 
     /**
      * Size of the dataset to be sampled or {@code 0} if a dataset size is not known.
      */
-    // TODO: With 0 being a legal dataset size, it would be nice to use a different "null" value, e.g., -1.
     protected long datasetSize;
 
     private Methods sampleMethod;
@@ -61,18 +66,17 @@ public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
      * Creates a new instance given the sample size.
      */
     public SampleOperator(int sampleSize, DataSetType<Type> type, Methods sampleMethod) {
-        super(type, type,
-                true);
-        this.sampleSize = sampleSize;
-        this.sampleMethod = sampleMethod;
+        this(sampleSize, UNKNOWN_DATASET_SIZE, type, sampleMethod);
     }
 
     /**
      * Creates a new instance given the sample size and total dataset size.
      */
     public SampleOperator(int sampleSize, long datasetSize, DataSetType<Type> type, Methods sampleMethod) {
-        this(sampleSize, type, sampleMethod);
+        super(type, type, true);
+        this.sampleSize = sampleSize;
         this.datasetSize = datasetSize;
+        this.sampleMethod = sampleMethod;
     }
 
     /**

--- a/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
+++ b/rheem-basic/src/main/java/org/qcri/rheem/basic/operators/SampleOperator.java
@@ -15,16 +15,47 @@ import java.util.Optional;
 public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
 
     public enum Methods {
-        BERNOULLI, //Bernoulli sampling
-        RANDOM, // Randomly pick a sample
-        SHUFFLE_FIRST, // shuffle data first and then take sequentially the sample
-        RESERVOIR //reservoir sampling
+        /**
+         * Represents an arbitrary sampling method.
+         */
+        ANY,
+        /**
+         * Bernoulli sampling.
+         */
+        BERNOULLI,
+        /**
+         * Randomly pick a sample.
+         */
+        RANDOM,
+        /**
+         * Shuffle the data first, then sequentially take the sample.
+         */
+        SHUFFLE_FIRST,
+        /**
+         * Reservoir sampling.
+         */
+        RESERVOIR
     }
 
     protected int sampleSize;
+
+    /**
+     * Size of the dataset to be sampled or {@code 0} if a dataset size is not known.
+     */
+    // TODO: With 0 being a legal dataset size, it would be nice to use a different "null" value, e.g., -1.
     protected long datasetSize;
 
-    protected Methods sampleMethod;
+    private Methods sampleMethod;
+
+    /**
+     * Creates a new instance with any sampling method.
+     *
+     * @param sampleSize size of the sample
+     * @param type       {@link DataSetType} of the sampled dataset
+     */
+    public SampleOperator(int sampleSize, DataSetType<Type> type) {
+        this(sampleSize, type, Methods.ANY);
+    }
 
     /**
      * Creates a new instance given the sample size.
@@ -37,7 +68,7 @@ public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
     }
 
     /**
-     *  Creates a new instance given the sample size and total dataset size.
+     * Creates a new instance given the sample size and total dataset size.
      */
     public SampleOperator(int sampleSize, long datasetSize, DataSetType<Type> type, Methods sampleMethod) {
         this(sampleSize, type, sampleMethod);
@@ -57,13 +88,21 @@ public class SampleOperator<Type> extends UnaryToUnaryOperator<Type, Type> {
     }
 
 
-    public DataSetType getType() { return this.getInputType(); }
+    public DataSetType<Type> getType() {
+        return this.getInputType();
+    }
 
-    public int getSampleSize() { return this.sampleSize; }
+    public int getSampleSize() {
+        return this.sampleSize;
+    }
 
-    public long getDatasetSize() { return this.datasetSize; }
+    public long getDatasetSize() {
+        return this.datasetSize;
+    }
 
-    public Methods getSampleMethod() { return this.sampleMethod; }
+    public Methods getSampleMethod() {
+        return this.sampleMethod;
+    }
 
     @Override
     public Optional<CardinalityEstimator> createCardinalityEstimator(

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/SampleMapping.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/mapping/SampleMapping.java
@@ -4,9 +4,9 @@ import org.qcri.rheem.basic.operators.SampleOperator;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.mapping.*;
 import org.qcri.rheem.core.types.DataSetType;
-import org.qcri.rheem.java.platform.JavaPlatform;
 import org.qcri.rheem.java.operators.JavaRandomSampleOperator;
 import org.qcri.rheem.java.operators.JavaReservoirSampleOperator;
+import org.qcri.rheem.java.platform.JavaPlatform;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +32,7 @@ public class SampleMapping implements Mapping {
         ).withAdditionalTest(op ->
                 op.getSampleMethod() == SampleOperator.Methods.RANDOM
                         || op.getSampleMethod() == SampleOperator.Methods.RESERVOIR
+                        || op.getSampleMethod() == SampleOperator.Methods.ANY
         );
         return SubplanPattern.createSingleton(operatorPattern);
     }
@@ -40,6 +41,7 @@ public class SampleMapping implements Mapping {
         return new ReplacementSubplanFactory.OfSingleOperators<SampleOperator>(
                 (matchedOperator, epoch) -> {
                     switch (matchedOperator.getSampleMethod()) {
+                        case ANY:
                         case RANDOM:
                             return new JavaRandomSampleOperator<>(matchedOperator).at(epoch);
                         case RESERVOIR:

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
@@ -65,9 +65,8 @@ public class JavaRandomSampleOperator<Type>
         assert inputs.length == this.getNumInputs();
         assert outputs.length == this.getNumOutputs();
 
-        // FIXME: If the dataset size is unknown, we execute the Stream twice, which should not happen.
-        if (datasetSize == 0) //total size of input dataset was not given
-            datasetSize = ((JavaChannelInstance) inputs[0]).provideStream().count();
+        long datasetSize = this.isDataSetSizeKnown() ? this.getDatasetSize() :
+            ((CollectionChannel.Instance) inputs[0]).provideCollection().size();
 
         if (sampleSize >= datasetSize) { //return all
             ((StreamChannel.Instance) outputs[0]).accept(((JavaChannelInstance) inputs[0]).provideStream());
@@ -121,7 +120,10 @@ public class JavaRandomSampleOperator<Type>
     @Override
     public List<ChannelDescriptor> getSupportedInputChannels(int index) {
         assert index <= this.getNumInputs() || (index == 0 && this.getNumInputs() == 0);
-        return Arrays.asList(CollectionChannel.DESCRIPTOR, StreamChannel.DESCRIPTOR);
+        return this.isDataSetSizeKnown() ?
+            Arrays.asList(CollectionChannel.DESCRIPTOR, StreamChannel.DESCRIPTOR) :
+            Collections.singletonList(CollectionChannel.DESCRIPTOR);
+
     }
 
     @Override

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaRandomSampleOperator.java
@@ -26,14 +26,14 @@ public class JavaRandomSampleOperator<Type>
         extends SampleOperator<Type>
         implements JavaExecutionOperator {
 
-    Random rand = new Random();
+    private final Random rand = new Random();
 
     /**
      * Creates a new instance.
      *
      * @param sampleSize size of sample
      */
-    public JavaRandomSampleOperator(int sampleSize, DataSetType type) {
+    public JavaRandomSampleOperator(int sampleSize, DataSetType<Type> type) {
         super(sampleSize, type, Methods.RANDOM);
     }
 
@@ -43,7 +43,7 @@ public class JavaRandomSampleOperator<Type>
      * @param sampleSize  size of sample
      * @param datasetSize size of data
      */
-    public JavaRandomSampleOperator(int sampleSize, long datasetSize, DataSetType type) {
+    public JavaRandomSampleOperator(int sampleSize, long datasetSize, DataSetType<Type> type) {
         super(sampleSize, datasetSize, type, Methods.RANDOM);
     }
 

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/operators/JavaReservoirSampleOperator.java
@@ -25,14 +25,14 @@ public class JavaReservoirSampleOperator<Type>
         extends SampleOperator<Type>
         implements JavaExecutionOperator {
 
-    Random rand = new Random();
+    private final Random rand = new Random();
 
     /**
      * Creates a new instance.
      *
      * @param sampleSize
      */
-    public JavaReservoirSampleOperator(int sampleSize, DataSetType type) {
+    public JavaReservoirSampleOperator(int sampleSize, DataSetType<Type> type) {
         super(sampleSize, type, Methods.RESERVOIR);
     }
 
@@ -42,7 +42,7 @@ public class JavaReservoirSampleOperator<Type>
      * @param sampleSize
      * @param datasetSize
      */
-    public JavaReservoirSampleOperator(int sampleSize, long datasetSize, DataSetType type) {
+    public JavaReservoirSampleOperator(int sampleSize, long datasetSize, DataSetType<Type> type) {
         super(sampleSize, datasetSize, type, Methods.RESERVOIR);
     }
 
@@ -53,6 +53,7 @@ public class JavaReservoirSampleOperator<Type>
      */
     public JavaReservoirSampleOperator(SampleOperator<Type> that) {
         super(that);
+        assert that.getSampleMethod() == Methods.RESERVOIR || that.getSampleMethod() == Methods.ANY;
     }
 
     @Override

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/SampleMapping.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/mapping/SampleMapping.java
@@ -34,6 +34,7 @@ public class SampleMapping implements Mapping {
                 op.getSampleMethod() == SampleOperator.Methods.RANDOM
                         || op.getSampleMethod() == SampleOperator.Methods.SHUFFLE_FIRST
                         || op.getSampleMethod() == SampleOperator.Methods.BERNOULLI
+                        || op.getSampleMethod() == SampleOperator.Methods.ANY
         ); //TODO: check if the zero here affects execution
         return SubplanPattern.createSingleton(operatorPattern);
     }
@@ -42,6 +43,7 @@ public class SampleMapping implements Mapping {
         return new ReplacementSubplanFactory.OfSingleOperators<SampleOperator>(
                 (matchedOperator, epoch) -> {
                     switch (matchedOperator.getSampleMethod()) {
+                        case ANY:
                         case RANDOM:
                             return new SparkRandomPartitionSampleOperator<>(matchedOperator);
                         case SHUFFLE_FIRST:

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkBernoulliSampleOperator.java
@@ -33,7 +33,7 @@ public class SparkBernoulliSampleOperator<Type>
      *
      * @param sampleSize
      */
-    public SparkBernoulliSampleOperator(int sampleSize, DataSetType type) {
+    public SparkBernoulliSampleOperator(int sampleSize, DataSetType<Type> type) {
         super(sampleSize, type, Methods.BERNOULLI);
     }
 
@@ -43,7 +43,7 @@ public class SparkBernoulliSampleOperator<Type>
      * @param sampleSize
      * @param datasetSize
      */
-    public SparkBernoulliSampleOperator(int sampleSize, long datasetSize, DataSetType type) {
+    public SparkBernoulliSampleOperator(int sampleSize, long datasetSize, DataSetType<Type> type) {
         super(sampleSize, datasetSize, type, Methods.BERNOULLI);
     }
 
@@ -54,6 +54,7 @@ public class SparkBernoulliSampleOperator<Type>
      */
     public SparkBernoulliSampleOperator(SampleOperator<Type> that) {
         super(that);
+        assert that.getSampleMethod() == Methods.BERNOULLI || that.getSampleMethod() == Methods.ANY;
     }
 
     @Override

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkRandomPartitionSampleOperator.java
@@ -77,10 +77,9 @@ public class SparkRandomPartitionSampleOperator<Type>
         RddChannel.Instance input = (RddChannel.Instance) inputs[0];
 
         final JavaRDD<Object> inputRdd = input.provideRdd();
-        if (datasetSize == 0) //total size of input dataset was not given
-        {
-            datasetSize = inputRdd.cache().count();
-        }
+        long datasetSize = this.isDataSetSizeKnown() ?
+                this.getDatasetSize() :
+                inputRdd.cache().count();
 
         if (sampleSize >= datasetSize) { //return whole dataset
             ((CollectionChannel.Instance) outputs[0]).accept(inputRdd.collect());
@@ -166,7 +165,9 @@ public class SparkRandomPartitionSampleOperator<Type>
     @Override
     public List<ChannelDescriptor> getSupportedInputChannels(int index) {
         assert index <= this.getNumInputs() || (index == 0 && this.getNumInputs() == 0);
-        return Arrays.asList(RddChannel.UNCACHED_DESCRIPTOR, RddChannel.CACHED_DESCRIPTOR);
+        return this.isDataSetSizeKnown() ?
+                Arrays.asList(RddChannel.UNCACHED_DESCRIPTOR, RddChannel.CACHED_DESCRIPTOR) :
+                Collections.singletonList(RddChannel.CACHED_DESCRIPTOR);
     }
 
     @Override

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/operators/SparkShufflePartitionSampleOperator.java
@@ -71,8 +71,9 @@ public class SparkShufflePartitionSampleOperator<Type>
         RddChannel.Instance input = (RddChannel.Instance) inputs[0];
 
         JavaRDD<Type> inputRdd = input.provideRdd();
-        if (datasetSize == 0) //total size of input dataset was not given
-            datasetSize = inputRdd.cache().count();
+        long datasetSize = this.isDataSetSizeKnown() ?
+                this.getDatasetSize() :
+                inputRdd.cache().count();
 
         if (sampleSize >= datasetSize) { //return all and return
             ((CollectionChannel.Instance) outputs[0]).accept(inputRdd.collect());


### PR DESCRIPTION
This PR introduces `sample(...)` methods to the APIs. Also, it contains some refactorings of the `SampleOperator` and its implementations.