### PR TITLE
[Rheem-27] Add platform costs into the cost model

### DIFF
--- a/rheem-core/src/main/java/org/qcri/rheem/core/api/Configuration.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/api/Configuration.java
@@ -85,7 +85,7 @@ public class Configuration {
 
     private ExplicitCollectionProvider<ChannelConversion> channelConversionProvider;
 
-    private ValueProvider<Comparator<TimeEstimate>> timeEstimateComparatorProvider;
+    private ValueProvider<Comparator<ProbabilisticDoubleInterval>> costEstimateComparatorProvider;
 
     private CollectionProvider<Class<PlanEnumerationPruningStrategy>> pruningStrategyClassProvider;
 
@@ -150,7 +150,7 @@ public class Configuration {
 
             // Providers for plan enumeration.
             this.pruningStrategyClassProvider = new ExplicitCollectionProvider<>(this, this.parent.pruningStrategyClassProvider);
-            this.timeEstimateComparatorProvider = new ConstantValueProvider<>(this, this.parent.timeEstimateComparatorProvider);
+            this.costEstimateComparatorProvider = new ConstantValueProvider<>(this, this.parent.costEstimateComparatorProvider);
             this.instrumentationStrategyProvider = new ConstantValueProvider<>(this, this.parent.instrumentationStrategyProvider);
 
             // Properties.
@@ -448,13 +448,6 @@ public class Configuration {
                     new MapBasedKeyValueProvider<>(builtInProvider, false);
             configuration.setTimeToCostConverterProvider(overrideProvider);
         }
-        {
-            ValueProvider<Comparator<TimeEstimate>> defaultProvider =
-                    new ConstantValueProvider<>(TimeEstimate.expectationValueComparator(), configuration);
-            ValueProvider<Comparator<TimeEstimate>> overrideProvider =
-                    new ConstantValueProvider<>(defaultProvider);
-            configuration.setTimeEstimateComparatorProvider(overrideProvider);
-        }
     }
 
     private static void bootstrapPruningProviders(Configuration configuration) {
@@ -486,11 +479,11 @@ public class Configuration {
             configuration.setPruningStrategyClassProvider(overrideProvider);
         }
         {
-            ValueProvider<Comparator<TimeEstimate>> defaultProvider =
-                    new ConstantValueProvider<>(TimeEstimate.expectationValueComparator(), configuration);
-            ValueProvider<Comparator<TimeEstimate>> overrideProvider =
+            ValueProvider<Comparator<ProbabilisticDoubleInterval>> defaultProvider =
+                    new ConstantValueProvider<>(ProbabilisticDoubleInterval.expectationValueComparator(), configuration);
+            ValueProvider<Comparator<ProbabilisticDoubleInterval>> overrideProvider =
                     new ConstantValueProvider<>(defaultProvider);
-            configuration.setTimeEstimateComparatorProvider(overrideProvider);
+            configuration.setCostEstimateComparatorProvider(overrideProvider);
         }
         {
             ValueProvider<InstrumentationStrategy> defaultProvider =
@@ -612,12 +605,12 @@ public class Configuration {
         this.channelConversionProvider = channelConversionProvider;
     }
 
-    public ValueProvider<Comparator<TimeEstimate>> getTimeEstimateComparatorProvider() {
-        return this.timeEstimateComparatorProvider;
+    public ValueProvider<Comparator<ProbabilisticDoubleInterval>> getCostEstimateComparatorProvider() {
+        return this.costEstimateComparatorProvider;
     }
 
-    public void setTimeEstimateComparatorProvider(ValueProvider<Comparator<TimeEstimate>> timeEstimateComparatorProvider) {
-        this.timeEstimateComparatorProvider = timeEstimateComparatorProvider;
+    public void setCostEstimateComparatorProvider(ValueProvider<Comparator<ProbabilisticDoubleInterval>> costEstimateComparatorProvider) {
+        this.costEstimateComparatorProvider = costEstimateComparatorProvider;
     }
 
     public CollectionProvider<Class<PlanEnumerationPruningStrategy>> getPruningStrategyClassProvider() {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticDoubleInterval.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticDoubleInterval.java
@@ -1,5 +1,6 @@
 package org.qcri.rheem.core.optimizer;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 /***
@@ -7,6 +8,35 @@ import java.util.Objects;
  * It addresses uncertainty by expressing estimates as intervals and assigning a probability of correctness (in [0, 1]).
  */
 public class ProbabilisticDoubleInterval {
+
+    /**
+     * Instance that basically represents the value {@code 0d}.
+     */
+    public static final ProbabilisticDoubleInterval zero = ProbabilisticDoubleInterval.ofExactly(0d);
+
+    /**
+     * Provides a {@link Comparator} for {@link ProbabilisticDoubleInterval}s.
+     * For two {@link ProbabilisticDoubleInterval}s {@code t1} and {@code t2}, it works as follows:
+     * <ol>
+     * <li>If a either of the {@link ProbabilisticDoubleInterval}s has a correctness probability of 0, we consider it to be greater.</li>
+     * <li>Otherwise, we compare the two {@link ProbabilisticDoubleInterval}s by their average estimation value.</li>
+     * </ol>
+     *
+     * @return
+     */
+    public static Comparator<ProbabilisticDoubleInterval> expectationValueComparator() {
+        return (t1, t2) -> {
+            if (t1.getCorrectnessProbability() == 0d) {
+                if (t2.getCorrectnessProbability() != 0d) {
+                    return 1;
+                }
+            } else if (t2.getCorrectnessProbability() == 0d) {
+                return -1;
+            }
+            // NB: We do not assume a uniform distribution of the estimates within the instances.
+            return Long.compare(t1.getGeometricMeanEstimate(), t2.getGeometricMeanEstimate());
+        };
+    }
 
     /**
      * Probability of correctness between in the interval [0, 1]. This helps
@@ -79,6 +109,20 @@ public class ProbabilisticDoubleInterval {
         return this.correctnessProb == 1d && this.lowerEstimate == this.upperEstimate && this.upperEstimate == exactEstimate;
     }
 
+    /**
+     * Creates a new instance that represents the sum of the {@code this} and {@code that} instance.
+     *
+     * @param that the other summand
+     * @return the sum
+     */
+    public ProbabilisticDoubleInterval plus(ProbabilisticDoubleInterval that) {
+        return new ProbabilisticDoubleInterval(
+                this.getLowerEstimate() + that.getLowerEstimate(),
+                this.getUpperEstimate() + that.getUpperEstimate(),
+                Math.min(this.getCorrectnessProbability(), that.getCorrectnessProbability())
+        );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -112,7 +156,8 @@ public class ProbabilisticDoubleInterval {
 
     @Override
     public String toString() {
-        return String.format("%s[%.2f..%.2f, %.1f%%]", this.getClass().getSimpleName(),
+        return String.format("%s[%,.2f..%,.2f, %.1f%%]", this.getClass().getSimpleName(),
                 this.lowerEstimate, this.upperEstimate, this.correctnessProb * 100d);
     }
+
 }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticDoubleInterval.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticDoubleInterval.java
@@ -156,7 +156,7 @@ public class ProbabilisticDoubleInterval {
 
     @Override
     public String toString() {
-        return String.format("%s[%,.2f..%,.2f, %.1f%%]", this.getClass().getSimpleName(),
+        return String.format("(%,.2f..%,.2f ~ %.1f%%)",
                 this.lowerEstimate, this.upperEstimate, this.correctnessProb * 100d);
     }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticIntervalEstimate.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/ProbabilisticIntervalEstimate.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.core.optimizer;
 
 import org.qcri.rheem.core.util.Formats;
 
+import java.util.Comparator;
 import java.util.Objects;
 
 /***
@@ -71,6 +72,23 @@ public class ProbabilisticIntervalEstimate {
      */
     public boolean isExactly(long exactEstimate) {
         return this.correctnessProb == 1d && this.lowerEstimate == this.upperEstimate && this.upperEstimate == exactEstimate;
+    }
+
+    /**
+     * Creates a {@link Comparator} based on the mean of instances.
+     */
+    public static <T extends ProbabilisticIntervalEstimate> Comparator<T> expectationValueComparator() {
+        return (t1, t2) -> {
+            if (t1.getCorrectnessProbability() == 0d) {
+                if (t2.getCorrectnessProbability() != 0d) {
+                    return 1;
+                }
+            } else if (t2.getCorrectnessProbability() == 0d) {
+                return -1;
+            }
+            // NB: We do not assume a uniform distribution of the estimates within the instances.
+            return Long.compare(t1.getGeometricMeanEstimate(), t2.getGeometricMeanEstimate());
+        };
     }
 
     @Override

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/cardinality/CardinalityPusher.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/cardinality/CardinalityPusher.java
@@ -54,8 +54,8 @@ public abstract class CardinalityPusher {
             this.doPush(opCtx, configuration);
         }
 
-        if (opCtx.getTimeEstimate() == null) {
-            opCtx.updateTimeEstimate();
+        if (opCtx.getCostEstimate() == null) {
+            opCtx.updateCostEstimate();
         }
     }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversion.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/ChannelConversion.java
@@ -3,8 +3,8 @@ package org.qcri.rheem.core.optimizer.channels;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.DefaultOptimizationContext;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
-import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.plan.executionplan.Channel;
 import org.qcri.rheem.core.plan.rheemplan.Operator;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
@@ -60,29 +60,31 @@ public abstract class ChannelConversion {
     }
 
     /**
-     * Estimate the required time to carry out the conversion for a given {@code cardinality}.
+     * Estimate the required costs to carry out the conversion for a given {@code cardinality}.
      *
      * @param cardinality   the {@link CardinalityEstimate} of data to be converted
      * @param numExecutions expected number of executions of this instance
      * @param configuration provides estimators
-     * @return the {@link TimeEstimate}
-     * @see #estimateConversionTime(CardinalityEstimate, int, OptimizationContext)
+     * @return the cost estimate
+     * @see #estimateConversionCost(CardinalityEstimate, int, OptimizationContext)
      */
-    public TimeEstimate estimateConversionTime(CardinalityEstimate cardinality, int numExecutions, Configuration configuration) {
-        return this.estimateConversionTime(cardinality, numExecutions, new DefaultOptimizationContext(configuration));
+    public ProbabilisticDoubleInterval estimateConversionCost(CardinalityEstimate cardinality,
+                                                              int numExecutions,
+                                                              Configuration configuration) {
+        return this.estimateConversionCost(cardinality, numExecutions, new DefaultOptimizationContext(configuration));
     }
 
     /**
-     * Estimate the required time to carry out the conversion for a given {@code cardinality}.
+     * Estimate the required cost to carry out the conversion for a given {@code cardinality}.
      *
      * @param cardinality         the {@link CardinalityEstimate} of data to be converted
      * @param numExecutions       expected number of executions of this instance
      * @param optimizationContext provides a {@link Configuration} and keeps around generated optimization information
-     * @return the {@link TimeEstimate}
+     * @return the cost estimate
      */
-    public abstract TimeEstimate estimateConversionTime(CardinalityEstimate cardinality,
-                                                        int numExecutions,
-                                                        OptimizationContext optimizationContext);
+    public abstract ProbabilisticDoubleInterval estimateConversionCost(CardinalityEstimate cardinality,
+                                                                       int numExecutions,
+                                                                       OptimizationContext optimizationContext);
 
     @Override
     public String toString() {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
@@ -131,7 +131,7 @@ public class DefaultChannelConversion extends ChannelConversion {
             operatorContext.setOutputCardinality(0, cardinality);
         }
 
-        operatorContext.updateTimeEstimate();
+        operatorContext.updateCostEstimate();
     }
 
     @Override
@@ -145,7 +145,7 @@ public class DefaultChannelConversion extends ChannelConversion {
         this.setCardinality(operatorContext, cardinality);
 
         // Estimate time.
-        operatorContext.updateTimeEstimate();
+        operatorContext.updateCostEstimate();
         return operatorContext.getTimeEstimate();
     }
 

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/channels/DefaultChannelConversion.java
@@ -2,8 +2,8 @@ package org.qcri.rheem.core.optimizer.channels;
 
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
-import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.plan.executionplan.Channel;
 import org.qcri.rheem.core.plan.executionplan.ExecutionTask;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
@@ -116,8 +116,8 @@ public class DefaultChannelConversion extends ChannelConversion {
      * @param cardinality         the {@link CardinalityEstimate}
      */
     private void setCardinalityAndTimeEstimate(ExecutionTask conversionTask,
-                                OptimizationContext optimizationContext,
-                                CardinalityEstimate cardinality) {
+                                               OptimizationContext optimizationContext,
+                                               CardinalityEstimate cardinality) {
         final ExecutionOperator operator = conversionTask.getOperator();
         final OptimizationContext.OperatorContext operatorContext = optimizationContext.addOneTimeOperator(operator);
 
@@ -135,7 +135,9 @@ public class DefaultChannelConversion extends ChannelConversion {
     }
 
     @Override
-    public TimeEstimate estimateConversionTime(CardinalityEstimate cardinality, int numExecutions, OptimizationContext optimizationContext) {
+    public ProbabilisticDoubleInterval estimateConversionCost(CardinalityEstimate cardinality,
+                                                              int numExecutions,
+                                                              OptimizationContext optimizationContext) {
         // Create OperatorContext.
         final ExecutionOperator executionOperator = this.executionOperatorFactory.apply(null, optimizationContext.getConfiguration());
         final OptimizationContext.OperatorContext operatorContext = optimizationContext.addOneTimeOperator(executionOperator);
@@ -146,7 +148,7 @@ public class DefaultChannelConversion extends ChannelConversion {
 
         // Estimate time.
         operatorContext.updateCostEstimate();
-        return operatorContext.getTimeEstimate();
+        return operatorContext.getCostEstimate();
     }
 
     private void setCardinality(OptimizationContext.OperatorContext operatorContext, CardinalityEstimate cardinality) {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeEstimate.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeEstimate.java
@@ -38,29 +38,6 @@ public class TimeEstimate extends ProbabilisticIntervalEstimate {
         );
     }
 
-    /**
-     * Provides a {@link Comparator} for {@link TimeEstimate}s. For two {@link TimeEstimate}s {@code t1} and {@code t2},
-     * it works as follows:
-     * <ol>
-     *     <li>If a either of the {@link TimeEstimate}s has a correctness probability of 0, we consider it to be greater.</li>
-     *     <li>Otherwise, we compare the two {@link TimeEstimate}s by their average estimation value.</li>
-     * </ol>
-     * @return
-     */
-    public static Comparator<TimeEstimate> expectationValueComparator() {
-        return (t1, t2) -> {
-            if (t1.getCorrectnessProbability() == 0d) {
-                if (t2.getCorrectnessProbability() != 0d) {
-                    return 1;
-                }
-            } else if (t2.getCorrectnessProbability() == 0d) {
-                return -1;
-            }
-            // NB: We do not assume a uniform distribution of the estimates within the instances.
-            return Long.compare(t1.getGeometricMeanEstimate(), t2.getGeometricMeanEstimate());
-        };
-    }
-
     public TimeEstimate times(double scalar) {
         return scalar == 1d ? this : new TimeEstimate(
                 Math.round(this.getLowerEstimate() * scalar),

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeToCostConverter.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeToCostConverter.java
@@ -39,4 +39,35 @@ public class TimeToCostConverter {
         double upperBound = this.fixCosts + this.costsPerMilli * timeEstimate.getUpperEstimate();
         return new ProbabilisticDoubleInterval(lowerBound, upperBound, timeEstimate.getCorrectnessProbability());
     }
+
+
+    /**
+     * Convert the given {@link TimeEstimate} into a cost estimate without considering the fix costs.
+     *
+     * @param timeEstimate the {@link TimeEstimate}
+     * @return the cost estimate
+     */
+    public ProbabilisticDoubleInterval convertWithoutFixCosts(TimeEstimate timeEstimate) {
+        double lowerBound = this.costsPerMilli * timeEstimate.getLowerEstimate();
+        double upperBound = this.costsPerMilli * timeEstimate.getUpperEstimate();
+        return new ProbabilisticDoubleInterval(lowerBound, upperBound, timeEstimate.getCorrectnessProbability());
+    }
+
+    /**
+     * Get the fix costs, i.e., the overhead, that incur according to this instance.
+     *
+     * @return the fix costs
+     */
+    public double getFixCosts() {
+        return this.fixCosts;
+    }
+
+    /**
+     * Get the costs that incur per millisecond according to this instance.
+     *
+     * @return the costs per milliseond
+     */
+    public double getCostsPerMillisecond() {
+        return this.costsPerMilli;
+    }
 }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeToCostConverter.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/costs/TimeToCostConverter.java
@@ -1,0 +1,42 @@
+package org.qcri.rheem.core.optimizer.costs;
+
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
+
+/**
+ * This (linear) converter turns {@link TimeEstimate}s into cost estimates.
+ */
+public class TimeToCostConverter {
+
+    /**
+     * The fix costs to be paid in some context.
+     */
+    private final double fixCosts;
+
+    /**
+     * The costs per millisecond.
+     */
+    private final double costsPerMilli;
+
+    /**
+     * Creates a new instance
+     *
+     * @param fixCosts      the fix costs to be paid in some context.
+     * @param costsPerMilli the costs per millisecond
+     */
+    public TimeToCostConverter(double fixCosts, double costsPerMilli) {
+        this.fixCosts = fixCosts;
+        this.costsPerMilli = costsPerMilli;
+    }
+
+    /**
+     * Convert the given {@link TimeEstimate} into a cost estimate.
+     *
+     * @param timeEstimate the {@link TimeEstimate}
+     * @return the cost estimate
+     */
+    public ProbabilisticDoubleInterval convert(TimeEstimate timeEstimate) {
+        double lowerBound = this.fixCosts + this.costsPerMilli * timeEstimate.getLowerEstimate();
+        double upperBound = this.fixCosts + this.costsPerMilli * timeEstimate.getUpperEstimate();
+        return new ProbabilisticDoubleInterval(lowerBound, upperBound, timeEstimate.getCorrectnessProbability());
+    }
+}

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/LoopImplementation.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/LoopImplementation.java
@@ -1,5 +1,6 @@
 package org.qcri.rheem.core.optimizer.enumeration;
 
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.plan.rheemplan.*;
 import org.qcri.rheem.core.platform.Junction;
@@ -53,6 +54,22 @@ public class LoopImplementation {
             timeEstimate = timeEstimate.plus(this.iterationImplementations.get(i).getTimeEstimate());
         }
         return timeEstimate;
+    }
+
+    /**
+     * Retrieve the cost estimate for this instance. Fix costs are not excluded.
+     *
+     * @return the cost estimate
+     */
+    public ProbabilisticDoubleInterval getCostEstimate() {
+        // What about the Junctions? Are they already included?
+        // Yes, in-loop Junctions are contained in the body implementations and the surrounding Junctions are
+        // contained in the top-level PlanImplementation.
+        ProbabilisticDoubleInterval costEstimate = ProbabilisticDoubleInterval.zero;
+        for (int i = 0; i < this.iterationImplementations.size(); i++) {
+            costEstimate = costEstimate.plus(this.iterationImplementations.get(i).getCostEstimate());
+        }
+        return costEstimate;
     }
 
     public List<IterationImplementation> getIterationImplementations() {
@@ -171,6 +188,15 @@ public class LoopImplementation {
          */
         public TimeEstimate getTimeEstimate() {
             return this.bodyImplementation.getTimeEstimate(false);
+        }
+
+        /**
+         * Retrieve the cost estimate for this instance. Global overhead is not included.
+         *
+         * @return the cost estimate
+         */
+        public ProbabilisticDoubleInterval getCostEstimate() {
+            return this.bodyImplementation.getCostEstimate(false);
         }
 
         /**

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/TopKPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/TopKPruningStrategy.java
@@ -1,7 +1,7 @@
 package org.qcri.rheem.core.optimizer.enumeration;
 
 import org.qcri.rheem.core.api.Configuration;
-import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -11,13 +11,13 @@ import java.util.Comparator;
  */
 public class TopKPruningStrategy implements PlanEnumerationPruningStrategy {
 
-    private Comparator<TimeEstimate> timeEstimateComparator;
+    private Comparator<ProbabilisticDoubleInterval> costEstimateComparator;
 
     private int k;
 
     @Override
     public void configure(Configuration configuration) {
-        this.timeEstimateComparator = configuration.getTimeEstimateComparatorProvider().provide();
+        this.costEstimateComparator = configuration.getCostEstimateComparatorProvider().provide();
         this.k = (int) configuration.getLongProperty("rheem.core.optimizer.pruning.topk", 5);
     }
 
@@ -33,9 +33,9 @@ public class TopKPruningStrategy implements PlanEnumerationPruningStrategy {
 
     private int comparePlanImplementations(PlanImplementation p1,
                                            PlanImplementation p2) {
-        final TimeEstimate t1 = p1.getTimeEstimate();
-        final TimeEstimate t2 = p2.getTimeEstimate();
-        return this.timeEstimateComparator.compare(t1, t2);
+        final ProbabilisticDoubleInterval t1 = p1.getCostEstimate(true);
+        final ProbabilisticDoubleInterval t2 = p2.getCostEstimate(true);
+        return this.costEstimateComparator.compare(t1, t2);
     }
 
 }

--- a/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/OperatorBase.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/plan/rheemplan/OperatorBase.java
@@ -6,7 +6,6 @@ import org.qcri.rheem.core.function.*;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimate;
 import org.qcri.rheem.core.optimizer.cardinality.CardinalityEstimator;
-import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.platform.Platform;
 import org.qcri.rheem.core.types.DataSetType;
 import org.qcri.rheem.core.util.Tuple;
@@ -56,11 +55,6 @@ public abstract class OperatorBase implements Operator {
      * Optional name. Helpful for debugging.
      */
     private String name;
-
-    /**
-     * Can assign a {@link TimeEstimate} to {@link ExecutionOperator}s.
-     */
-    private TimeEstimate timeEstimate;
 
     public OperatorBase(InputSlot<?>[] inputSlots, OutputSlot<?>[] outputSlots, boolean isSupportingBroadcastInputs) {
         this.container = null;
@@ -186,20 +180,6 @@ public abstract class OperatorBase implements Operator {
     @Override
     public void addTargetPlatform(Platform platform) {
         this.targetPlatforms.add(platform);
-    }
-
-    public TimeEstimate getTimeEstimate() {
-        if (!this.isExecutionOperator()) {
-            throw new IllegalStateException("Cannot retrieve time estimate for non-execution operator " + this);
-        }
-        return this.timeEstimate;
-    }
-
-    public void setTimeEstimate(TimeEstimate timeEstimate) {
-        if (!this.isExecutionOperator()) {
-            throw new IllegalStateException("Cannot set time estimate for non-execution operator " + this);
-        }
-        this.timeEstimate = timeEstimate;
     }
 
     @Override

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/Junction.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/Junction.java
@@ -1,6 +1,7 @@
 package org.qcri.rheem.core.platform;
 
 import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.plan.executionplan.Channel;
 import org.qcri.rheem.core.plan.executionplan.ExecutionTask;
@@ -123,6 +124,23 @@ public class Junction {
                 .map(localMatchingOptCtx::getOperatorContext)
                 .map(OptimizationContext.OperatorContext::getTimeEstimate)
                 .reduce(TimeEstimate.ZERO, TimeEstimate::plus);
+    }
+
+    /**
+     * Calculates the cost estimate for all {@link ExecutionOperator}s in this instance for a given
+     * {@link OptimizationContext} that should be known itself (or as a fork) to this instance.
+     *
+     * @param optimizationContext the {@link OptimizationContext}
+     * @return the aggregate cost estimate
+     */
+    public ProbabilisticDoubleInterval getCostEstimate(OptimizationContext optimizationContext) {
+        final OptimizationContext localMatchingOptCtx = this.findMatchingOptimizationContext(optimizationContext);
+        assert localMatchingOptCtx != null : "No matching OptimizationContext for in Junction.";
+        return this.conversionTasks.stream()
+                .map(ExecutionTask::getOperator)
+                .map(localMatchingOptCtx::getOperatorContext)
+                .map(OptimizationContext.OperatorContext::getCostEstimate)
+                .reduce(ProbabilisticDoubleInterval.zero, ProbabilisticDoubleInterval::plus);
     }
 
     /**

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/PartialExecution.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/PartialExecution.java
@@ -28,6 +28,11 @@ public class PartialExecution implements JsonSerializable {
     private final long measuredExecutionTime;
 
     /**
+     * Cost bounds for this instance.
+     */
+    private final double lowerCost, upperCost;
+
+    /**
      * {@link OptimizationContext.OperatorContext}s captured by this instance.
      */
     transient private final Collection<OptimizationContext.OperatorContext> operatorContexts;
@@ -46,11 +51,15 @@ public class PartialExecution implements JsonSerializable {
      * Creates a new instance.
      *
      * @param measuredExecutionTime the time measured for the partial execution
+     * @param lowerCost             the lower possible costs for the new instance
+     * @param upperCost             the upper possible costs for the new instance
      * @param operatorContexts      for all executed {@link ExecutionOperator}s
      */
-    public PartialExecution(long measuredExecutionTime, Collection<OptimizationContext.OperatorContext> operatorContexts) {
+    public PartialExecution(long measuredExecutionTime, double lowerCost, double upperCost, Collection<OptimizationContext.OperatorContext> operatorContexts) {
         this.measuredExecutionTime = measuredExecutionTime;
         this.operatorContexts = operatorContexts;
+        this.lowerCost = lowerCost;
+        this.upperCost = upperCost;
     }
 
     /**
@@ -60,10 +69,20 @@ public class PartialExecution implements JsonSerializable {
         this.measuredExecutionTime = measuredExecutionTime;
         this.operatorContexts = null;
         this.operatorExecutions = executions;
+        this.lowerCost = Double.NaN;
+        this.upperCost = Double.NaN;
     }
 
     public long getMeasuredExecutionTime() {
         return measuredExecutionTime;
+    }
+
+    public double getMeasuredLowerCost() {
+        return this.lowerCost;
+    }
+
+    public double getMeasuredUpperCost() {
+        return this.upperCost;
     }
 
     public Collection<OptimizationContext.OperatorContext> getOperatorContexts() {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/Platform.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/Platform.java
@@ -4,6 +4,7 @@ import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.Job;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.plan.executionplan.Channel;
 import org.qcri.rheem.core.plan.executionplan.ExecutionTask;
 import org.qcri.rheem.core.plan.executionplan.PlatformExecution;
@@ -89,6 +90,14 @@ public abstract class Platform {
      * @return a default {@link LoadProfileToTimeConverter}
      */
     public abstract LoadProfileToTimeConverter createLoadProfileToTimeConverter(Configuration configuration);
+
+    /**
+     * Creates a {@link TimeToCostConverter} for this instance.
+     *
+     * @param configuration configures the {@link TimeToCostConverter}
+     * @return the {@link TimeToCostConverter}
+     */
+    public abstract TimeToCostConverter createTimeToCostConverter(Configuration configuration);
 
     /**
      * Warm up this instance.

--- a/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/platform/PushExecutorTemplate.java
@@ -116,22 +116,8 @@ public abstract class PushExecutorTemplate extends ExecutorTemplate {
 
         if (executedOperatorContexts.isEmpty()) return null;
 
-        // Calculate possible costs.
-        final Configuration configuration = this.getConfiguration();
-        double lowerCost = Double.POSITIVE_INFINITY, upperCost = Double.NEGATIVE_INFINITY;
-        final Set<Platform> platforms = executedOperatorContexts.stream()
-                .map(operatorContext -> ((ExecutionOperator) operatorContext.getOperator()).getPlatform())
-                .collect(Collectors.toSet());
-        for (Platform platform : platforms) {
-            final TimeToCostConverter timeToCostConverter = configuration.getTimeToCostConverterProvider().provideFor(platform);
-            final ProbabilisticDoubleInterval costs =
-                    timeToCostConverter.convertWithoutFixCosts(TimeEstimate.ZERO.plus(executionDuration));
-            lowerCost = Math.min(lowerCost, costs.getLowerEstimate());
-            upperCost = Math.max(upperCost, costs.getUpperEstimate());
-        }
-
-        final PartialExecution partialExecution = new PartialExecution(
-                executionDuration, lowerCost, upperCost, executedOperatorContexts
+        final PartialExecution partialExecution = PartialExecution.createFromMeasurement(
+                executionDuration, executedOperatorContexts, this.getConfiguration()
         );
         if (this.logger.isInfoEnabled()) {
             this.logger.info(

--- a/rheem-core/src/main/java/org/qcri/rheem/core/profiling/CostMeasurement.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/profiling/CostMeasurement.java
@@ -1,0 +1,66 @@
+package org.qcri.rheem.core.profiling;
+
+import de.hpi.isg.profiledb.store.model.Measurement;
+import de.hpi.isg.profiledb.store.model.Type;
+
+/**
+ * This measurement captures execution costs w.r.t. to Rheem's cost model.
+ */
+@Type("cost")
+public class CostMeasurement extends Measurement {
+
+    /**
+     * The cost is generally captures as bounding box and this is the lower or upper value, respectively.
+     */
+    private double lowerCost, upperCost;
+
+    /**
+     * The probability of the cost measurement being correct.
+     */
+    private double probability;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param id          the ID of the instance
+     * @param lowerCost   the lower bound of the cost
+     * @param upperCost   the upper bound of the cost
+     * @param probability the probability of the actual cost being within the bounds
+     */
+    public CostMeasurement(String id, double lowerCost, double upperCost, double probability) {
+        super(id);
+        this.lowerCost = lowerCost;
+        this.upperCost = upperCost;
+        this.probability = probability;
+    }
+
+    /**
+     * Deserialization constructor.
+     */
+    protected CostMeasurement() {
+    }
+
+    public double getLowerCost() {
+        return this.lowerCost;
+    }
+
+    public void setLowerCost(double lowerCost) {
+        this.lowerCost = lowerCost;
+    }
+
+    public double getUpperCost() {
+        return this.upperCost;
+    }
+
+    public void setUpperCost(double upperCost) {
+        this.upperCost = upperCost;
+    }
+
+    public double getProbability() {
+        return this.probability;
+    }
+
+    public void setProbability(double probability) {
+        this.probability = probability;
+    }
+}

--- a/rheem-core/src/main/java/org/qcri/rheem/core/profiling/ProfileDBs.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/profiling/ProfileDBs.java
@@ -26,9 +26,11 @@ public class ProfileDBs {
      * @param profileDB the {@link ProfileDB}
      */
     public static void customize(ProfileDB profileDB) {
-        profileDB.withGsonPreparation(
-                gsonBuilder -> gsonBuilder.registerTypeAdapter(Operator.class, new OperatorBase.GsonSerializer())
-        );
+        profileDB
+                .withGsonPreparation(
+                        gsonBuilder -> gsonBuilder.registerTypeAdapter(Operator.class, new OperatorBase.GsonSerializer())
+                )
+                .registerMeasurementClass(CostMeasurement.class);
     }
 
 }

--- a/rheem-core/src/test/java/org/qcri/rheem/core/platform/PartialExecutionTest.java
+++ b/rheem-core/src/test/java/org/qcri/rheem/core/platform/PartialExecutionTest.java
@@ -38,7 +38,7 @@ public class PartialExecutionTest {
         when(operatorContext2.getNumExecutions()).thenReturn(1);
 
 
-        PartialExecution original = new PartialExecution(12345L, Arrays.asList(operatorContext1, operatorContext2));
+        PartialExecution original = new PartialExecution(12345L, 12, 13, Arrays.asList(operatorContext1, operatorContext2));
         original.addInitializedPlatform(DummyPlatform.getInstance());
 
         final JSONObject jsonObject = JsonSerializables.serialize(original);

--- a/rheem-core/src/test/java/org/qcri/rheem/core/test/DummyPlatform.java
+++ b/rheem-core/src/test/java/org/qcri/rheem/core/test/DummyPlatform.java
@@ -45,4 +45,9 @@ public class DummyPlatform extends Platform {
             }
         };
     }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
+        return new TimeToCostConverter(0d, 1d);
+    }
 }

--- a/rheem-platforms/rheem-graphchi/src/main/java/org/qcri/rheem/graphchi/platform/GraphChiPlatform.java
+++ b/rheem-platforms/rheem-graphchi/src/main/java/org/qcri/rheem/graphchi/platform/GraphChiPlatform.java
@@ -4,6 +4,7 @@ import edu.cmu.graphchi.io.CompressedIO;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
 import org.qcri.rheem.core.optimizer.costs.LoadToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.Platform;
 import org.qcri.rheem.core.util.ReflectionUtils;
@@ -66,6 +67,14 @@ public class GraphChiPlatform extends Platform {
                 LoadToTimeConverter.createLinearCoverter(hdfsMsPerMb / 1000000),
                 LoadToTimeConverter.createLinearCoverter(0),
                 (cpuEstimate, diskEstimate, networkEstimate) -> cpuEstimate.plus(diskEstimate).plus(networkEstimate)
+        );
+    }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
+        return new TimeToCostConverter(
+                configuration.getDoubleProperty("rheem.graphchi.costs.fix"),
+                configuration.getDoubleProperty("rheem.graphchi.costs.per-ms")
         );
     }
 }

--- a/rheem-platforms/rheem-graphchi/src/main/resources/rheem-graphchi-defaults.properties
+++ b/rheem-platforms/rheem-graphchi/src/main/resources/rheem-graphchi-defaults.properties
@@ -1,3 +1,5 @@
 rheem.graphchi.cpu.mhz = 2700
 rheem.graphchi.cores = 2
 rheem.graphchi.hdfs.ms-per-mb = 2.7
+rheem.graphchi.costs.fix = 0.0
+rheem.graphchi.costs.per-ms = 1.0

--- a/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/platform/JavaPlatform.java
+++ b/rheem-platforms/rheem-java/src/main/java/org/qcri/rheem/java/platform/JavaPlatform.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.java.platform;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
 import org.qcri.rheem.core.optimizer.costs.LoadToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.Platform;
 import org.qcri.rheem.core.util.ReflectionUtils;
@@ -52,6 +53,14 @@ public class JavaPlatform extends Platform {
                 LoadToTimeConverter.createLinearCoverter(0),
                 (cpuEstimate, diskEstimate, networkEstimate) -> cpuEstimate.plus(diskEstimate).plus(networkEstimate),
                 stretch
+        );
+    }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
+        return new TimeToCostConverter(
+                configuration.getDoubleProperty("rheem.java.costs.fix"),
+                configuration.getDoubleProperty("rheem.java.costs.per-ms")
         );
     }
 }

--- a/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
+++ b/rheem-platforms/rheem-java/src/main/resources/rheem-java-defaults.properties
@@ -2,6 +2,8 @@ rheem.java.cpu.mhz = 2700
 rheem.java.cores = 1
 rheem.java.hdfs.ms-per-mb = 2.7
 rheem.java.stretch = 1
+rheem.java.costs.fix = 0.0
+rheem.java.costs.per-ms = 1.0
 
 rheem.java.map.load = {\
   "in":1, "out":1,\

--- a/rheem-platforms/rheem-jdbc-template/src/main/java/org/qcri/rheem/jdbc/platform/JdbcPlatformTemplate.java
+++ b/rheem-platforms/rheem-jdbc-template/src/main/java/org/qcri/rheem/jdbc/platform/JdbcPlatformTemplate.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.jdbc.platform;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
 import org.qcri.rheem.core.optimizer.costs.LoadToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.platform.ChannelDescriptor;
 import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.Platform;
@@ -66,6 +67,14 @@ public abstract class JdbcPlatformTemplate extends Platform {
                 LoadToTimeConverter.createLinearCoverter(0),
                 LoadToTimeConverter.createLinearCoverter(0),
                 (cpuEstimate, diskEstimate, networkEstimate) -> cpuEstimate.plus(diskEstimate).plus(networkEstimate)
+        );
+    }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
+        return new TimeToCostConverter(
+                configuration.getDoubleProperty(String.format("rheem.%s.costs.fix", this.getPlatformId())),
+                configuration.getDoubleProperty(String.format("rheem.%s.costs.per-ms", this.getPlatformId()))
         );
     }
 

--- a/rheem-platforms/rheem-jdbc-template/src/test/resources/rheem-hsqldb-defaults.properties
+++ b/rheem-platforms/rheem-jdbc-template/src/test/resources/rheem-hsqldb-defaults.properties
@@ -1,2 +1,4 @@
 # Use in-memory HSQLDB to avoid messing with files in the tests.
 rheem.hsqldb.jdbc.url = jdbc:hsqldb:mem:testdb
+rheem.hsqldb.costs.fix = 0.0
+rheem.hsqldb.costs.per-ms = 1.0

--- a/rheem-platforms/rheem-postgres/src/main/resources/rheem-postgres-defaults.properties
+++ b/rheem-platforms/rheem-postgres/src/main/resources/rheem-postgres-defaults.properties
@@ -3,6 +3,9 @@
 # Cost function parameters
 rheem.postgres.cpu.mhz = 2700
 rheem.postgres.cores = 2
+rheem.postgres.costs.fix = 0.0
+rheem.postgres.costs.per-ms = 1.0
+
 
 # NB: Not measured.
 rheem.postgres.tablesource.load = {\

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/platform/SparkPlatform.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/platform/SparkPlatform.java
@@ -8,6 +8,7 @@ import org.qcri.rheem.core.api.Job;
 import org.qcri.rheem.core.api.RheemContext;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
 import org.qcri.rheem.core.optimizer.costs.LoadToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.plan.rheemplan.RheemPlan;
 import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.Platform;
@@ -157,6 +158,14 @@ public class SparkPlatform extends Platform {
                 LoadToTimeConverter.createLinearCoverter(networkMsPerMb / 1000000d),
                 (cpuEstimate, diskEstimate, networkEstimate) -> cpuEstimate.plus(diskEstimate).plus(networkEstimate),
                 stretch
+        );
+    }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
+        return new TimeToCostConverter(
+                configuration.getDoubleProperty("rheem.spark.costs.fix"),
+                configuration.getDoubleProperty("rheem.spark.costs.per-ms")
         );
     }
 

--- a/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
+++ b/rheem-platforms/rheem-spark/src/main/resources/rheem-spark-defaults.properties
@@ -9,6 +9,8 @@ rheem.spark.hdfs.ms-per-mb = 2.7
 rheem.spark.network.ms-per-mb = 8.6
 rheem.spark.init.ms = 4500
 rheem.spark.stretch = 1
+rheem.spark.costs.fix = 0.0
+rheem.spark.costs.per-ms = 1.0
 
 rheem.spark.map.load = {\
   "in":1, "out":1,\

--- a/rheem-platforms/rheem-sqlite3/src/main/resources/rheem-sqlite3-defaults.properties
+++ b/rheem-platforms/rheem-sqlite3/src/main/resources/rheem-sqlite3-defaults.properties
@@ -1,6 +1,8 @@
 # rheem.sqlite3.jdbc.url = jdbc:sqlite:...
 rheem.sqlite3.cpu.mhz = 2700
 rheem.sqlite3.cores = 2
+rheem.sqlite3.costs.fix = 0.0
+rheem.sqlite3.costs.per-ms = 1.0
 
 # NB: Not measured.
 rheem.sqlite3.tablesource.load = {\

--- a/rheem-profiler/src/main/java/org/qcri/rheem/profiler/log/LogEvaluator.java
+++ b/rheem-profiler/src/main/java/org/qcri/rheem/profiler/log/LogEvaluator.java
@@ -3,6 +3,7 @@ package org.qcri.rheem.profiler.log;
 import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.api.exception.RheemException;
 import org.qcri.rheem.core.optimizer.OptimizationContext;
+import org.qcri.rheem.core.optimizer.ProbabilisticIntervalEstimate;
 import org.qcri.rheem.core.optimizer.costs.TimeEstimate;
 import org.qcri.rheem.core.plan.rheemplan.ExecutionOperator;
 import org.qcri.rheem.core.platform.PartialExecution;
@@ -161,7 +162,7 @@ public class LogEvaluator {
             System.out.println("sort clear");
             return;
         }
-        final Comparator<TimeEstimate> timeEstimateComparator = this.configuration.getTimeEstimateComparatorProvider().provide();
+        final Comparator<TimeEstimate> timeEstimateComparator = ProbabilisticIntervalEstimate.expectationValueComparator();
         switch (commandLine[1]) {
             case "clear":
                 this.sortCriterion = null;

--- a/rheem-tests/src/test/java/org/qcri/rheem/tests/platform/MyMadeUpPlatform.java
+++ b/rheem-tests/src/test/java/org/qcri/rheem/tests/platform/MyMadeUpPlatform.java
@@ -4,6 +4,7 @@ import org.qcri.rheem.core.api.Configuration;
 import org.qcri.rheem.core.mapping.Mapping;
 import org.qcri.rheem.core.optimizer.channels.ChannelConversion;
 import org.qcri.rheem.core.optimizer.costs.LoadProfileToTimeConverter;
+import org.qcri.rheem.core.optimizer.costs.TimeToCostConverter;
 import org.qcri.rheem.core.platform.Executor;
 import org.qcri.rheem.core.platform.Platform;
 import org.qcri.rheem.core.plugin.Plugin;
@@ -61,6 +62,11 @@ public class MyMadeUpPlatform extends Platform implements Plugin {
 
     @Override
     public LoadProfileToTimeConverter createLoadProfileToTimeConverter(Configuration configuration) {
+        throw new RuntimeException("Not yet implemented.");
+    }
+
+    @Override
+    public TimeToCostConverter createTimeToCostConverter(Configuration configuration) {
         throw new RuntimeException("Not yet implemented.");
     }
 }

--- a/rheem-tests/src/test/resources/rheem-hsqldb-defaults.properties
+++ b/rheem-tests/src/test/resources/rheem-hsqldb-defaults.properties
@@ -1,0 +1,2 @@
+rheem.hsqldb.costs.fix = 0.0
+rheem.hsqldb.costs.per-ms = 1.0


### PR DESCRIPTION
This PR introduces platform costs: Rheem's optimal plan is not chosen anymore by plain runtime but by costs. Costs are just a linear transformation from the (estimated) execution time spent on each platform to some abstract costs. However, the default cost transformation is basically an identity mapping, so existing plans behave as they did before.