### PR TITLE
Add a random pruning strategy

### DIFF
--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
@@ -381,9 +381,9 @@ public class PlanEnumerator {
                 );
                 if (branchEnumeration.getPlanImplementations().isEmpty()) {
                     if (this.isTopLevel()) {
-                        throw new RheemException(String.format("Could not concatenate %s in %s.", operator, branch));
+                        throw new RheemException(String.format("Could not concatenate %s to %s.", lastOperator, operator));
                     } else {
-                        this.logger.warn("Could not concatenate {} in {}.", operator, branch);
+                        this.logger.warn("Could not concatenate {} to {}.", lastOperator, operator);
                     }
                 }
                 this.prune(branchEnumeration);

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/RandomPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/RandomPruningStrategy.java
@@ -1,0 +1,33 @@
+package org.qcri.rheem.core.optimizer.enumeration;
+
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
+
+import java.util.*;
+
+/**
+ * This {@link PlanEnumerationPruningStrategy} retains only the best {@code k} {@link PlanImplementation}s.
+ */
+@SuppressWarnings("unused")
+public class RandomPruningStrategy implements PlanEnumerationPruningStrategy {
+
+    private Random random;
+
+    private int numRetainedPlans;
+
+    @Override
+    public void configure(Configuration configuration) {
+        this.numRetainedPlans = (int) configuration.getLongProperty("rheem.core.optimizer.pruning.random.retain", 1);
+        long seed = configuration.getLongProperty("rheem.core.optimizer.pruning.random.seed", System.currentTimeMillis());
+        this.random = new Random(seed);
+    }
+
+    @Override
+    public void prune(PlanEnumeration planEnumeration) {
+        if (planEnumeration.getPlanImplementations().size() <= this.numRetainedPlans) return;
+
+        ArrayList<PlanImplementation> planImplementations = new ArrayList<>(planEnumeration.getPlanImplementations());
+        Collections.shuffle(planImplementations, this.random);
+        planEnumeration.getPlanImplementations().retainAll(planImplementations.subList(0, this.numRetainedPlans));
+    }
+}


### PR DESCRIPTION
This PR introduces the `RandomPruningStrategy`, which randomly prunes plan implementations during the plan enumeration. This is particularly useful to obtain training data for learning cost functions.