### PR TITLE
Single-platform pruning strategy

### DIFF
--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/LatentOperatorPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/LatentOperatorPruningStrategy.java
@@ -33,6 +33,9 @@ public class LatentOperatorPruningStrategy implements PlanEnumerationPruningStra
 
     @Override
     public void prune(PlanEnumeration planEnumeration) {
+        // Skip if there is nothing to do...
+        if (planEnumeration.getPlanImplementations().size() < 2) return;
+
         // Group plans.
         final Collection<List<PlanImplementation>> competingPlans =
                 planEnumeration.getPlanImplementations().stream()

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanEnumerator.java
@@ -658,11 +658,6 @@ public class PlanEnumerator {
      * @param planEnumeration to which the pruning should be applied
      */
     private void prune(final PlanEnumeration planEnumeration) {
-        if (planEnumeration.getPlanImplementations().size() < 2) {
-            this.logger.trace("Skip pruning: Too few plan implementations.");
-            return;
-        }
-
         if (this.logger.isDebugEnabled()) {
             this.logger.debug("{} implementations for scope {}.", planEnumeration.getPlanImplementations().size(), planEnumeration.getScope());
             for (PlanImplementation planImplementation : planEnumeration.getPlanImplementations()) {

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanImplementation.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/PlanImplementation.java
@@ -677,6 +677,10 @@ public class PlanImplementation {
         }
     }
 
+    /**
+     * Retrieve the {@link Platform}s that are utilized by this instance.
+     * @return the {@link Platform}s
+     */
     public Set<Platform> getUtilizedPlatforms() {
         if (this.platformCache == null) {
             this.platformCache = this.streamOperators()

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/RandomPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/RandomPruningStrategy.java
@@ -1,9 +1,10 @@
 package org.qcri.rheem.core.optimizer.enumeration;
 
 import org.qcri.rheem.core.api.Configuration;
-import org.qcri.rheem.core.optimizer.ProbabilisticDoubleInterval;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
 
 /**
  * This {@link PlanEnumerationPruningStrategy} retains only the best {@code k} {@link PlanImplementation}s.

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/SinglePlatformPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/SinglePlatformPruningStrategy.java
@@ -1,0 +1,29 @@
+package org.qcri.rheem.core.optimizer.enumeration;
+
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.platform.Platform;
+
+/**
+ * This {@link PlanEnumerationPruningStrategy} retains only the best {@link PlanImplementation}s employing a single
+ * {@link Platform} only.
+ * <p>There is one caveat, though: If for some reason the most efficient way to communicate for two
+ * {@link org.qcri.rheem.core.plan.rheemplan.ExecutionOperator}s from the same {@link Platform} goes over another
+ * {@link Platform}, then we will prune the corresponding {@link PlanImplementation}. The more complete way is to
+ * look only for non-cross-platform {@link org.qcri.rheem.core.platform.Junction}s. We neglect this issue for now.</p>
+ */
+@SuppressWarnings("unused")
+public class SinglePlatformPruningStrategy implements PlanEnumerationPruningStrategy {
+
+
+    @Override
+    public void configure(Configuration configuration) {
+    }
+
+    @Override
+    public void prune(PlanEnumeration planEnumeration) {
+        planEnumeration.getPlanImplementations().removeIf(
+                planImplementation -> planImplementation.getUtilizedPlatforms().size() > 1
+        );
+    }
+
+}

--- a/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/TopKPruningStrategy.java
+++ b/rheem-core/src/main/java/org/qcri/rheem/core/optimizer/enumeration/TopKPruningStrategy.java
@@ -23,6 +23,7 @@ public class TopKPruningStrategy implements PlanEnumerationPruningStrategy {
 
     @Override
     public void prune(PlanEnumeration planEnumeration) {
+        // Skip if there is nothing to do...
         if (planEnumeration.getPlanImplementations().size() <= this.k) return;
 
         ArrayList<PlanImplementation> planImplementations = new ArrayList<>(planEnumeration.getPlanImplementations());

--- a/rheem-platforms/rheem-postgres/src/main/java/org/qcri/rheem/postgres/Postgres.java
+++ b/rheem-platforms/rheem-postgres/src/main/java/org/qcri/rheem/postgres/Postgres.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.postgres;
 
 
 import org.qcri.rheem.postgres.platform.PostgresPlatform;
+import org.qcri.rheem.postgres.plugin.PostgresConversionsPlugin;
 import org.qcri.rheem.postgres.plugin.PostgresPlugin;
 
 /**
@@ -11,6 +12,8 @@ public class Postgres {
 
     private final static PostgresPlugin PLUGIN = new PostgresPlugin();
 
+    private final static PostgresConversionsPlugin CONVERSIONS_PLUGIN = new PostgresConversionsPlugin();
+
     /**
      * Retrieve the {@link PostgresPlugin}.
      *
@@ -18,6 +21,15 @@ public class Postgres {
      */
     public static PostgresPlugin plugin() {
         return PLUGIN;
+    }
+
+    /**
+     * Retrieve the {@link PostgresConversionsPlugin}.
+     *
+     * @return the {@link PostgresConversionsPlugin}
+     */
+    public static PostgresConversionsPlugin conversionPlugin() {
+        return CONVERSIONS_PLUGIN;
     }
 
 

--- a/rheem-platforms/rheem-postgres/src/main/java/org/qcri/rheem/postgres/plugin/PostgresConversionsPlugin.java
+++ b/rheem-platforms/rheem-postgres/src/main/java/org/qcri/rheem/postgres/plugin/PostgresConversionsPlugin.java
@@ -1,0 +1,41 @@
+package org.qcri.rheem.postgres.plugin;
+
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.mapping.Mapping;
+import org.qcri.rheem.core.optimizer.channels.ChannelConversion;
+import org.qcri.rheem.core.plan.rheemplan.Operator;
+import org.qcri.rheem.core.platform.Platform;
+import org.qcri.rheem.core.plugin.Plugin;
+import org.qcri.rheem.java.platform.JavaPlatform;
+import org.qcri.rheem.postgres.channels.ChannelConversions;
+import org.qcri.rheem.postgres.mapping.Mappings;
+import org.qcri.rheem.postgres.platform.PostgresPlatform;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This {@link Plugin} enables to use some basic Rheem {@link Operator}s on the {@link PostgresPlatform}.
+ */
+public class PostgresConversionsPlugin implements Plugin {
+
+    @Override
+    public Collection<Platform> getRequiredPlatforms() {
+        return Arrays.asList(PostgresPlatform.getInstance(), JavaPlatform.getInstance());
+    }
+
+    @Override
+    public Collection<Mapping> getMappings() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<ChannelConversion> getChannelConversions() {
+        return ChannelConversions.ALL;
+    }
+
+    @Override
+    public void setProperties(Configuration configuration) {
+    }
+}

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/Spark.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/Spark.java
@@ -2,6 +2,7 @@ package org.qcri.rheem.spark;
 
 import org.qcri.rheem.spark.platform.SparkPlatform;
 import org.qcri.rheem.spark.plugin.SparkBasicPlugin;
+import org.qcri.rheem.spark.plugin.SparkConversionPlugin;
 import org.qcri.rheem.spark.plugin.SparkGraphPlugin;
 
 /**
@@ -12,6 +13,8 @@ public class Spark {
     private final static SparkBasicPlugin PLUGIN = new SparkBasicPlugin();
 
     private final static SparkGraphPlugin GRAPH_PLUGIN = new SparkGraphPlugin();
+
+    private final static SparkConversionPlugin CONVERSION_PLUGIN = new SparkConversionPlugin();
 
     /**
      * Retrieve the {@link SparkBasicPlugin}.
@@ -29,6 +32,15 @@ public class Spark {
      */
     public static SparkGraphPlugin graphPlugin() {
         return GRAPH_PLUGIN;
+    }
+
+    /**
+     * Retrieve the {@link SparkConversionPlugin}.
+     *
+     * @return the {@link SparkConversionPlugin}
+     */
+    public static SparkConversionPlugin conversionPlugin() {
+        return CONVERSION_PLUGIN;
     }
 
     /**

--- a/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/plugin/SparkConversionPlugin.java
+++ b/rheem-platforms/rheem-spark/src/main/java/org/qcri/rheem/spark/plugin/SparkConversionPlugin.java
@@ -1,0 +1,43 @@
+package org.qcri.rheem.spark.plugin;
+
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.mapping.Mapping;
+import org.qcri.rheem.core.optimizer.channels.ChannelConversion;
+import org.qcri.rheem.core.plan.rheemplan.Operator;
+import org.qcri.rheem.core.platform.Platform;
+import org.qcri.rheem.core.plugin.Plugin;
+import org.qcri.rheem.java.platform.JavaPlatform;
+import org.qcri.rheem.spark.channels.ChannelConversions;
+import org.qcri.rheem.spark.mapping.Mappings;
+import org.qcri.rheem.spark.platform.SparkPlatform;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This {@link Plugin} enables to create {@link org.apache.spark.rdd.RDD}s.
+ */
+public class SparkConversionPlugin implements Plugin {
+
+    @Override
+    public Collection<Mapping> getMappings() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<ChannelConversion> getChannelConversions() {
+        return ChannelConversions.ALL;
+    }
+
+    @Override
+    public Collection<Platform> getRequiredPlatforms() {
+        return Arrays.asList(SparkPlatform.getInstance(), JavaPlatform.getInstance());
+    }
+
+    @Override
+    public void setProperties(Configuration configuration) {
+        // Nothing to do, because we already configured the properties in #configureDefaults(...).
+    }
+
+}

--- a/rheem-platforms/rheem-sqlite3/src/main/java/org/qcri/rheem/sqlite3/Sqlite3.java
+++ b/rheem-platforms/rheem-sqlite3/src/main/java/org/qcri/rheem/sqlite3/Sqlite3.java
@@ -1,6 +1,7 @@
 package org.qcri.rheem.sqlite3;
 
 import org.qcri.rheem.sqlite3.platform.Sqlite3Platform;
+import org.qcri.rheem.sqlite3.plugin.Sqlite3ConversionPlugin;
 import org.qcri.rheem.sqlite3.plugin.Sqlite3Plugin;
 
 /**
@@ -10,6 +11,8 @@ public class Sqlite3 {
 
     private final static Sqlite3Plugin PLUGIN = new Sqlite3Plugin();
 
+    private final static Sqlite3ConversionPlugin CONVERSION_PLUGIN = new Sqlite3ConversionPlugin();
+
     /**
      * Retrieve the {@link Sqlite3Plugin}.
      *
@@ -17,6 +20,15 @@ public class Sqlite3 {
      */
     public static Sqlite3Plugin plugin() {
         return PLUGIN;
+    }
+
+    /**
+     * Retrieve the {@link Sqlite3ConversionPlugin}.
+     *
+     * @return the {@link Sqlite3ConversionPlugin}
+     */
+    public static Sqlite3ConversionPlugin conversionPlugin() {
+        return CONVERSION_PLUGIN;
     }
 
 
@@ -28,5 +40,5 @@ public class Sqlite3 {
     public static Sqlite3Platform platform() {
         return Sqlite3Platform.getInstance();
     }
-    
+
 }

--- a/rheem-platforms/rheem-sqlite3/src/main/java/org/qcri/rheem/sqlite3/plugin/Sqlite3ConversionPlugin.java
+++ b/rheem-platforms/rheem-sqlite3/src/main/java/org/qcri/rheem/sqlite3/plugin/Sqlite3ConversionPlugin.java
@@ -1,0 +1,39 @@
+package org.qcri.rheem.sqlite3.plugin;
+
+import org.qcri.rheem.core.api.Configuration;
+import org.qcri.rheem.core.mapping.Mapping;
+import org.qcri.rheem.core.optimizer.channels.ChannelConversion;
+import org.qcri.rheem.core.platform.Platform;
+import org.qcri.rheem.core.plugin.Plugin;
+import org.qcri.rheem.java.platform.JavaPlatform;
+import org.qcri.rheem.sqlite3.channels.ChannelConversions;
+import org.qcri.rheem.sqlite3.platform.Sqlite3Platform;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This {@link Plugin} provides {@link ChannelConversion}s from the  {@link Sqlite3Platform}.
+ */
+public class Sqlite3ConversionPlugin implements Plugin {
+
+    @Override
+    public Collection<Platform> getRequiredPlatforms() {
+        return Arrays.asList(Sqlite3Platform.getInstance(), JavaPlatform.getInstance());
+    }
+
+    @Override
+    public Collection<Mapping> getMappings() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<ChannelConversion> getChannelConversions() {
+        return ChannelConversions.ALL;
+    }
+
+    @Override
+    public void setProperties(Configuration configuration) {
+    }
+}


### PR DESCRIPTION
This PR introduces a `PlanEnumerationPruningStrategy` to prune `PlanImplementation`s with more than one utilized `Platform`. Activating this pruning strategy basically takes the cross-platform execution from Rheem and only allows for platform independence. However, it is not activated by default.

Furthermore, the PR sneaks in new `Plugin`s for `Spark`, `Sqlite3`, and `Postgres` that expose only `ChannelConversion`s of the respective platform.